### PR TITLE
bench: add criterion harness for compositing and shader-params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +985,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clang-sys"
@@ -1327,6 +1366,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2684,6 +2759,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2784,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3905,6 +4000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4065,6 +4166,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -5173,6 +5302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5544,6 +5683,7 @@ dependencies = [
  "bytemuck",
  "clap",
  "cpal",
+ "criterion",
  "crossbeam-channel",
  "ctrlc",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,16 @@ ctrlc = "3.5.2"
 test-fixtures = []
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 egui_kittest = { version = "0.33.3", features = ["wgpu", "snapshot"] }
 tempfile = "3.27.0"
 tower = { version = "0.5.3", features = ["util"] }
 varda = { path = ".", features = ["test-fixtures"] }
+
+[[bench]]
+name = "compositing"
+harness = false
+
+[[bench]]
+name = "shader_params"
+harness = false

--- a/benches/compositing.rs
+++ b/benches/compositing.rs
@@ -1,0 +1,206 @@
+/// GPU compositing benchmarks at 1080p.
+///
+///   channel_composite_solid  — solid-color decks (LoadOp::Clear, no fragment shader).
+///                              The slope across deck counts isolates per-deck
+///                              copy-on-composite cost. The level at decks/1
+///                              includes fixed render-pass setup, not just
+///                              compositing.
+///
+///   channel_composite_shader — same shape but with bars.fs running on every
+///                              pixel. Difference vs solid at N decks ≈
+///                              N × per-deck shader execution cost.
+///
+///   mixer_crossfade          — two channels through the crossfader at 50%.
+///
+/// After the criterion groups complete, the per-deck slope (decks/8 minus
+/// decks/1, divided by 7) is computed from fresh samples and printed.
+
+use std::time::Instant;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use varda::{
+    audio::AudioData,
+    deck::Deck,
+    isf::ISFShader,
+    mixer::Mixer,
+    modulation::AudioValues,
+    renderer::context::GpuContext,
+};
+
+const WIDTH: u32 = 1920;
+const HEIGHT: u32 = 1080;
+
+/// 60fps frame budget. Preflight panics if 8-deck solid composite at 1080p
+/// exceeds this. Disable with `VARDA_BENCH_SKIP_SLO=1`.
+const FRAME_BUDGET_US: u128 = 16_670;
+
+const BARS_SHADER: &str = include_str!("../shaders/bars.fs");
+
+fn make_context() -> Option<GpuContext> {
+    GpuContext::new_headless().ok()
+}
+
+fn poll(ctx: &GpuContext) {
+    ctx.device
+        .poll(wgpu::PollType::Wait { submission_index: None, timeout: None })
+        .ok();
+}
+
+fn setup_mixer_solid(context: &GpuContext, n_decks: usize) -> Mixer {
+    let mut mixer = Mixer::new(context, WIDTH, HEIGHT).expect("mixer");
+    let ch = mixer.channel_mut(0).expect("channel 0");
+    for i in 0..n_decks {
+        let t = i as f32 / n_decks.max(1) as f32;
+        let deck = Deck::new_solid_color(context, [t, 0.5, 1.0 - t, 1.0], WIDTH, HEIGHT)
+            .expect("solid color deck");
+        ch.add_deck(deck);
+    }
+    mixer
+}
+
+fn setup_mixer_shader(context: &GpuContext, n_decks: usize) -> Mixer {
+    let mut mixer = Mixer::new(context, WIDTH, HEIGHT).expect("mixer");
+    let ch = mixer.channel_mut(0).expect("channel 0");
+    for _ in 0..n_decks {
+        let shader = ISFShader::from_string(BARS_SHADER).expect("bars shader");
+        let deck = Deck::new(context, shader, WIDTH, HEIGHT).expect("shader deck");
+        ch.add_deck(deck);
+    }
+    mixer
+}
+
+fn time_render_us(ctx: &GpuContext, mixer: &mut Mixer, samples: usize) -> u128 {
+    let audio = AudioData::default();
+    let audio_values = AudioValues { sources: Default::default() };
+    for _ in 0..3 {
+        mixer.render(ctx, &audio, &audio_values).expect("warmup");
+        poll(ctx);
+    }
+    let mut times = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let t0 = Instant::now();
+        mixer.render(ctx, &audio, &audio_values).expect("render");
+        poll(ctx);
+        times.push(t0.elapsed().as_micros());
+    }
+    times.sort_unstable();
+    times[samples / 2]
+}
+
+/// Preflight: assert the 8-deck render fits the 60fps budget. Runs once
+/// before any criterion sampling. Skipped when VARDA_BENCH_SKIP_SLO is set.
+fn preflight_slo(ctx: &GpuContext) {
+    if std::env::var_os("VARDA_BENCH_SKIP_SLO").is_some() {
+        return;
+    }
+    let mut mixer = setup_mixer_solid(ctx, 8);
+    let median = time_render_us(ctx, &mut mixer, 11);
+    if median > FRAME_BUDGET_US {
+        panic!(
+            "SLO violation: 8-deck solid composite at {WIDTH}x{HEIGHT} \
+             median = {median}µs, exceeds 60fps budget {FRAME_BUDGET_US}µs"
+        );
+    }
+    eprintln!("preflight: 8-deck solid composite median = {median}µs (budget {FRAME_BUDGET_US}µs)");
+}
+
+fn bench_channel_composite_solid(c: &mut Criterion) {
+    let Some(ctx) = make_context() else {
+        eprintln!("no GPU adapter — skipping");
+        return;
+    };
+    preflight_slo(&ctx);
+
+    let audio = AudioData::default();
+    let audio_values = AudioValues { sources: Default::default() };
+
+    let mut group = c.benchmark_group("channel_composite_solid");
+    group.sample_size(50);
+
+    for n_decks in [1, 2, 4, 8] {
+        let mut mixer = setup_mixer_solid(&ctx, n_decks);
+        group.bench_with_input(BenchmarkId::new("decks", n_decks), &n_decks, |b, _| {
+            b.iter(|| {
+                mixer.render(&ctx, &audio, &audio_values).expect("render");
+                poll(&ctx);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_channel_composite_shader(c: &mut Criterion) {
+    let Some(ctx) = make_context() else {
+        eprintln!("no GPU adapter — skipping");
+        return;
+    };
+
+    let audio = AudioData::default();
+    let audio_values = AudioValues { sources: Default::default() };
+
+    let mut group = c.benchmark_group("channel_composite_shader");
+    group.sample_size(50);
+
+    for n_decks in [1, 2, 4, 8] {
+        let mut mixer = setup_mixer_shader(&ctx, n_decks);
+        group.bench_with_input(BenchmarkId::new("decks", n_decks), &n_decks, |b, _| {
+            b.iter(|| {
+                mixer.render(&ctx, &audio, &audio_values).expect("render");
+                poll(&ctx);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_mixer_crossfade(c: &mut Criterion) {
+    let Some(ctx) = make_context() else {
+        eprintln!("no GPU adapter — skipping");
+        return;
+    };
+
+    let audio = AudioData::default();
+    let audio_values = AudioValues { sources: Default::default() };
+
+    let mut mixer = setup_mixer_solid(&ctx, 1);
+    let deck = Deck::new_solid_color(&ctx, [0.0, 1.0, 0.5, 1.0], WIDTH, HEIGHT)
+        .expect("solid color deck");
+    mixer.channel_mut(1).unwrap().add_deck(deck);
+    mixer.set_crossfader(0.5);
+
+    let mut group = c.benchmark_group("mixer_crossfade");
+    group.sample_size(50);
+    group.bench_function("2ch_50pct", |b| {
+        b.iter(|| {
+            mixer.render(&ctx, &audio, &audio_values).expect("render");
+            poll(&ctx);
+        });
+    });
+    group.finish();
+}
+
+/// Re-times solid composites at 1 and 8 decks (warmed, median of 11) and
+/// prints the per-deck slope to stderr.
+fn report_per_deck_slope(_c: &mut Criterion) {
+    let Some(ctx) = make_context() else { return };
+    let mut m1 = setup_mixer_solid(&ctx, 1);
+    let mut m8 = setup_mixer_solid(&ctx, 8);
+    let t1 = time_render_us(&ctx, &mut m1, 11);
+    let t8 = time_render_us(&ctx, &mut m8, 11);
+    let slope = (t8 as i128 - t1 as i128) / 7;
+    eprintln!(
+        "per-deck copy-on-composite slope (solid, {WIDTH}x{HEIGHT}): \
+         {slope}µs/deck   [decks/1={t1}µs, decks/8={t8}µs]"
+    );
+}
+
+criterion_group!(
+    benches,
+    bench_channel_composite_solid,
+    bench_channel_composite_shader,
+    bench_mixer_crossfade,
+    report_per_deck_slope,
+);
+criterion_main!(benches);

--- a/benches/shader_params.rs
+++ b/benches/shader_params.rs
@@ -1,0 +1,99 @@
+/// Per-frame CPU cost of building the shader parameter buffer.
+///
+/// Three variants per param count:
+///   no_mod     — std140 byte buffer serialization only.
+///   empty_mod  — modulation engine present but no assignments.
+///                Isolates the cost of the per-param key construction
+///                (currently a `format!` allocation).
+///   active_lfo — full modulation path: lookup, LFO read, clamp, write.
+///
+/// The (empty_mod − no_mod) gap is the per-param allocation cost paid even
+/// when nothing is modulated. Multiply by params × decks × effects to
+/// estimate the per-frame floor for a full scene.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use varda::{
+    isf::ISFInput,
+    modulation::{AudioValues, LFOWaveform, ModulationEngine, ModulationSource},
+    params::ShaderParams,
+};
+
+fn float_input(name: &str) -> ISFInput {
+    ISFInput {
+        name: name.to_string(),
+        input_type: "float".to_string(),
+        default: None,
+        min: Some(0.0),
+        max: Some(1.0),
+        label: None,
+        values: None,
+        labels: None,
+        identity: None,
+    }
+}
+
+fn color_input(name: &str) -> ISFInput {
+    ISFInput {
+        name: name.to_string(),
+        input_type: "color".to_string(),
+        default: None, min: None, max: None, label: None,
+        values: None, labels: None, identity: None,
+    }
+}
+
+fn point2d_input(name: &str) -> ISFInput {
+    ISFInput {
+        name: name.to_string(),
+        input_type: "point2D".to_string(),
+        default: None, min: None, max: None, label: None,
+        values: None, labels: None, identity: None,
+    }
+}
+
+fn make_params(n_floats: usize) -> ShaderParams {
+    let mut inputs: Vec<ISFInput> = (0..n_floats)
+        .map(|i| float_input(&format!("p{i}")))
+        .collect();
+    inputs.push(color_input("tint"));
+    inputs.push(point2d_input("center"));
+    ShaderParams::from_inputs(&inputs)
+}
+
+fn engine_with_lfo(param_key: &str) -> ModulationEngine {
+    let mut engine = ModulationEngine::new();
+    let src = engine.add_source(ModulationSource::LFO {
+        waveform: LFOWaveform::Sine,
+        frequency: 1.0,
+        phase: 0.0,
+        amplitude: 0.5,
+        bipolar: false,
+    });
+    engine.assign(param_key, &src, 1.0, None);
+    engine.update(0.5, &AudioValues { sources: Default::default() });
+    engine
+}
+
+fn bench_shader_params_buffer(c: &mut Criterion) {
+    let mut g = c.benchmark_group("shader_params_buffer");
+    g.sample_size(500);
+
+    for n_floats in [2usize, 6, 14] {
+        let params = make_params(n_floats);
+        let total = n_floats + 2;
+        let lfo_key = format!("deck0:p0");
+        let eng_empty = ModulationEngine::new();
+        let eng_lfo = engine_with_lfo(&lfo_key);
+
+        g.bench_with_input(BenchmarkId::new("no_mod", total), &total,
+            |b, _| b.iter(|| params.build_buffer_data()));
+        g.bench_with_input(BenchmarkId::new("empty_mod", total), &total,
+            |b, _| b.iter(|| params.build_modulated_buffer_data(&eng_empty, Some("deck0"))));
+        g.bench_with_input(BenchmarkId::new("active_lfo", total), &total,
+            |b, _| b.iter(|| params.build_modulated_buffer_data(&eng_lfo, Some("deck0"))));
+    }
+
+    g.finish();
+}
+
+criterion_group!(benches, bench_shader_params_buffer);
+criterion_main!(benches);

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,18 @@
+# Benchmarking
+
+```sh
+cargo bench --bench compositing      # GPU; needs an adapter, headless ok
+cargo bench --bench shader_params    # CPU only
+
+cargo bench --bench compositing -- --save-baseline <name>
+cargo bench --bench compositing -- --baseline <name>
+
+./scripts/bench-smoke.sh             # --test on both, no sampling
+```
+
+Criterion HTML reports land in `target/criterion/`.
+
+`compositing` runs at 1920×1080 and `device.poll(Wait)` after each iteration
+so wall-clock reflects GPU work. Without a GPU adapter it prints `no GPU
+adapter — skipping` and exits clean. Numbers are machine-local; close other
+GPU work and warm the machine for stability.

--- a/scripts/bench-smoke.sh
+++ b/scripts/bench-smoke.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Smoke-run both bench suites: verifies all cases compile and execute.
+# Fast exit — no statistics collected. Good for CI or pre-commit checks.
+set -euo pipefail
+
+cargo bench --bench shader_params -- --test
+cargo bench --bench compositing   -- --test


### PR DESCRIPTION
No benchmarks existed for the compositing pipeline or the per-frame shader parameter buffer build, so perf changes there land without quantitative evidence.

Adds a criterion harness — two GPU suites (`channel_composite_solid` for copy-on-composite slope, `channel_composite_shader` for total per-deck cost), `mixer_crossfade`, a CPU suite (`shader_params_buffer`), a 60fps preflight at 8-deck 1080p, and a per-deck slope reporter.

runnable as: `cargo bench --bench compositing` or `./scripts/bench-smoke.sh` for the headless `--test` path. A perf PR (`perf: ping-pong compositing`) follows this and uses the harness for verification: `cargo bench --bench compositing -- --save-baseline pre` and `--baseline pre` after the perf change reproduces the comparison on whichever machine you're on.