### PR TITLE
PERF: Performance optimizations, benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "varda"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,10 @@ harness = false
 name = "shader_params"
 harness = false
 
+[[bench]]
+name = "audio_analysis"
+harness = false
+
 
 [profile.release]
 opt-level = 3

--- a/benches/audio_analysis.rs
+++ b/benches/audio_analysis.rs
@@ -1,0 +1,57 @@
+/// Audio analysis hot-path benchmarks.
+///
+/// Two functions run inside the cpal audio callback (~every 5ms at 48kHz/256):
+///   onset_threshold  — median computation over spectral flux history (8 values)
+///   bpm_estimation   — median + outlier rejection over beat intervals (4-16 values)
+///
+/// Both currently clone + full-sort their input to compute a median.
+/// Benchmarks measure per-invocation cost at realistic window sizes.
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use varda::audio::{compute_onset_threshold, estimate_bpm};
+
+/// Realistic spectral flux values (positive, varying magnitude)
+fn make_flux_history(n: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| 0.01 + 0.05 * (i as f32 * 0.7).sin().abs())
+        .collect()
+}
+
+/// Realistic beat intervals centered around 120 BPM (0.5s) with slight jitter
+fn make_beat_intervals(n: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| 0.5 + 0.02 * (i as f32 * 1.3).sin())
+        .collect()
+}
+
+fn bench_onset_threshold(c: &mut Criterion) {
+    let mut g = c.benchmark_group("onset_threshold");
+    g.sample_size(1000);
+
+    // ONSET_MEDIAN_WINDOW = 8, but test a range
+    for n in [4, 8, 16] {
+        let flux = make_flux_history(n);
+        g.bench_with_input(BenchmarkId::new("clone_sort", n), &flux, |b, flux| {
+            b.iter(|| compute_onset_threshold(flux))
+        });
+    }
+    g.finish();
+}
+
+fn bench_bpm_estimation(c: &mut Criterion) {
+    let mut g = c.benchmark_group("bpm_estimation");
+    g.sample_size(1000);
+
+    // BPM_HISTORY_SIZE = 16, but test a range
+    for n in [4, 8, 16] {
+        let intervals = make_beat_intervals(n);
+        g.bench_with_input(
+            BenchmarkId::new("clone_sort", n),
+            &intervals,
+            |b, intervals| b.iter(|| estimate_bpm(intervals)),
+        );
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_onset_threshold, bench_bpm_estimation);
+criterion_main!(benches);

--- a/benches/shader_params.rs
+++ b/benches/shader_params.rs
@@ -112,5 +112,57 @@ fn bench_shader_params_buffer(c: &mut Criterion) {
     g.finish();
 }
 
-criterion_group!(benches, bench_shader_params_buffer);
+/// Measures the combined cost of prefix construction + modulated buffer build.
+///
+/// In the render loop, each deck/effect creates its prefix via format!() then
+/// passes it to build_modulated_buffer_data. This benchmark captures both
+/// steps together so we can measure the effect of caching the prefix.
+fn bench_prefix_construction(c: &mut Criterion) {
+    let mut g = c.benchmark_group("prefix_construction");
+    g.sample_size(500);
+
+    // Simulate the deck render path: format!("deck_{}", uuid) + modulated buffer build
+    let deck_uuid = "a1b2c3d4";
+    let fx_uuid = "e5f6a7b8";
+
+    for n_floats in [2usize, 6, 14] {
+        let params = make_params(n_floats);
+        let total = n_floats + 2;
+        let eng = ModulationEngine::new();
+
+        // Deck prefix: format!("deck_{}", uuid) each frame
+        g.bench_with_input(BenchmarkId::new("deck_format", total), &total, |b, _| {
+            b.iter(|| {
+                let prefix = format!("deck_{}", deck_uuid);
+                params.build_modulated_buffer_data(&eng, Some(&prefix))
+            })
+        });
+
+        // Effect prefix: format!("fx_{}", uuid) each frame
+        g.bench_with_input(BenchmarkId::new("fx_format", total), &total, |b, _| {
+            b.iter(|| {
+                let prefix = format!("fx_{}", fx_uuid);
+                params.build_modulated_buffer_data(&eng, Some(&prefix))
+            })
+        });
+
+        // Cached: prefix already exists, just pass &str (no allocation)
+        let cached_deck_prefix = format!("deck_{}", deck_uuid);
+        let cached_fx_prefix = format!("fx_{}", fx_uuid);
+        g.bench_with_input(BenchmarkId::new("deck_cached", total), &total, |b, _| {
+            b.iter(|| params.build_modulated_buffer_data(&eng, Some(&cached_deck_prefix)))
+        });
+        g.bench_with_input(BenchmarkId::new("fx_cached", total), &total, |b, _| {
+            b.iter(|| params.build_modulated_buffer_data(&eng, Some(&cached_fx_prefix)))
+        });
+    }
+
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_shader_params_buffer,
+    bench_prefix_construction
+);
 criterion_main!(benches);

--- a/benches/shader_params.rs
+++ b/benches/shader_params.rs
@@ -92,20 +92,31 @@ fn bench_shader_params_buffer(c: &mut Criterion) {
     g.sample_size(500);
 
     for n_floats in [2usize, 6, 14] {
-        let params = make_params(n_floats);
         let total = n_floats + 2;
         let lfo_key = format!("deck0:p0");
         let eng_empty = ModulationEngine::new();
         let eng_lfo = engine_with_lfo(&lfo_key);
 
+        let mut params_no = make_params(n_floats);
         g.bench_with_input(BenchmarkId::new("no_mod", total), &total, |b, _| {
-            b.iter(|| params.build_buffer_data())
+            b.iter(|| {
+                params_no.build_buffer_data();
+                criterion::black_box(params_no.scratch().len())
+            })
         });
+        let mut params_em = make_params(n_floats);
         g.bench_with_input(BenchmarkId::new("empty_mod", total), &total, |b, _| {
-            b.iter(|| params.build_modulated_buffer_data(&eng_empty, Some("deck0")))
+            b.iter(|| {
+                params_em.build_modulated_buffer_data(&eng_empty, Some("deck0"));
+                criterion::black_box(params_em.scratch().len())
+            })
         });
+        let mut params_lfo = make_params(n_floats);
         g.bench_with_input(BenchmarkId::new("active_lfo", total), &total, |b, _| {
-            b.iter(|| params.build_modulated_buffer_data(&eng_lfo, Some("deck0")))
+            b.iter(|| {
+                params_lfo.build_modulated_buffer_data(&eng_lfo, Some("deck0"));
+                criterion::black_box(params_lfo.scratch().len())
+            })
         });
     }
 
@@ -126,34 +137,45 @@ fn bench_prefix_construction(c: &mut Criterion) {
     let fx_uuid = "e5f6a7b8";
 
     for n_floats in [2usize, 6, 14] {
-        let params = make_params(n_floats);
         let total = n_floats + 2;
         let eng = ModulationEngine::new();
 
         // Deck prefix: format!("deck_{}", uuid) each frame
+        let mut params_df = make_params(n_floats);
         g.bench_with_input(BenchmarkId::new("deck_format", total), &total, |b, _| {
             b.iter(|| {
                 let prefix = format!("deck_{}", deck_uuid);
-                params.build_modulated_buffer_data(&eng, Some(&prefix))
+                params_df.build_modulated_buffer_data(&eng, Some(&prefix));
+                criterion::black_box(params_df.scratch().len())
             })
         });
 
         // Effect prefix: format!("fx_{}", uuid) each frame
+        let mut params_ff = make_params(n_floats);
         g.bench_with_input(BenchmarkId::new("fx_format", total), &total, |b, _| {
             b.iter(|| {
                 let prefix = format!("fx_{}", fx_uuid);
-                params.build_modulated_buffer_data(&eng, Some(&prefix))
+                params_ff.build_modulated_buffer_data(&eng, Some(&prefix));
+                criterion::black_box(params_ff.scratch().len())
             })
         });
 
         // Cached: prefix already exists, just pass &str (no allocation)
         let cached_deck_prefix = format!("deck_{}", deck_uuid);
         let cached_fx_prefix = format!("fx_{}", fx_uuid);
+        let mut params_dc = make_params(n_floats);
         g.bench_with_input(BenchmarkId::new("deck_cached", total), &total, |b, _| {
-            b.iter(|| params.build_modulated_buffer_data(&eng, Some(&cached_deck_prefix)))
+            b.iter(|| {
+                params_dc.build_modulated_buffer_data(&eng, Some(&cached_deck_prefix));
+                criterion::black_box(params_dc.scratch().len())
+            })
         });
+        let mut params_fc = make_params(n_floats);
         g.bench_with_input(BenchmarkId::new("fx_cached", total), &total, |b, _| {
-            b.iter(|| params.build_modulated_buffer_data(&eng, Some(&cached_fx_prefix)))
+            b.iter(|| {
+                params_fc.build_modulated_buffer_data(&eng, Some(&cached_fx_prefix));
+                criterion::black_box(params_fc.scratch().len())
+            })
         });
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Varda
 
-Varda is a free, open-source live visual mixer and broadcast router for Linux and macOS, written in Rust. It routes video sources — shaders, video files, cameras, NDI, SRT, HLS/DASH streams — through a broadcast-style signal matrix (Deck → Channel → Mixer → Surface → Output), composites them with per-parameter modulation and ISF effect chains, and delivers the result to projectors, network streams, recordings, and the web.
+Varda is a free, open-source live visual mixer and broadcast router for Linux, macOS, and Windows, written in Rust. It routes video sources — shaders, video files, cameras, NDI, SRT, HLS/DASH streams — through a broadcast-style signal matrix (Deck → Channel → Mixer → Surface → Output), composites them with per-parameter modulation and ISF effect chains, and delivers the result to projectors, network streams, recordings, and the web.
 
 Varda is built for live VJ performance, dome projection, multi-projector installations, and headless media serving — controlled via MIDI, OSC, keyboard shortcuts, or a full REST/WebSocket API.
 
@@ -13,12 +13,13 @@ Varda is built for live VJ performance, dome projection, multi-projector install
   - [Modulation](concepts.md#modulation) — LFO, audio bands, ADSR, step sequencer
   - [Persistence](concepts.md#persistence) — scene vs stage, presets, asset handling
 - [Getting Started](getting-started.md)
+  - [Install](getting-started.md#install) — macOS DMG, Linux tarball, Windows ZIP
   - [Workspace & Content](getting-started.md#workspace--content) — project layout, supported formats
-  - [Build & Run](getting-started.md#build--run)
+  - [Build from Source](getting-started.md#build-from-source)
   - [UI Layout](getting-started.md#ui-layout) — panel map
   - [Load Content](getting-started.md#load-content)
   - [Output to a Display](getting-started.md#output-to-a-display)
-  - [Audio Setup](getting-started.md#audio-setup) — input device, beat detection
+  - [Audio Reactivity](getting-started.md#audio-reactivity) — input device, beat detection
   - [Next Steps](getting-started.md#next-steps)
   - [CLI Flags](getting-started.md#cli-flags)
 - [Performance & Automation](performance.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,10 +1,40 @@
 # Getting Started
 
-## Prerequisites
+## Install
 
-- **Rust toolchain** — install via [rustup.rs](https://rustup.rs)
-- **GPU** — Vulkan-capable (Linux) or Metal-capable (macOS)
-- **ffmpeg** — required for video playback, recording, and streaming (`brew install ffmpeg` on macOS, or your package manager on Linux). Build with `--enable-libsrt` for SRT streaming support.
+Download the latest release from the [Releases page](https://github.com/im-knots/varda/releases). All releases bundle FFmpeg and NDI — no extra dependencies needed.
+
+### macOS (Universal DMG)
+
+1. Download `Varda-macOS-universal.dmg`
+2. Open the DMG and drag **Varda.app** to `/Applications`
+3. Before first launch, open Terminal and run:
+   ```bash
+   xattr -cr /Applications/Varda.app
+   ```
+   This removes the macOS quarantine flag. Varda is not yet signed with an Apple Developer certificate, so Gatekeeper will block it without this step.
+4. Launch Varda — on first run it will prompt for your password to install the `varda` CLI command to `/usr/local/bin/`
+
+### Linux (Portable Tarball)
+
+1. Download `Varda-Linux-x86_64.tar.gz`
+2. Extract and run:
+   ```bash
+   tar xzf Varda-Linux-x86_64.tar.gz
+   cd Varda-Linux-x86_64
+   ./varda
+   ```
+   Put the folder anywhere — on a USB drive, in your home directory, wherever. FFmpeg and codec libs are bundled.
+
+### Windows (Portable ZIP)
+
+1. Download `Varda-Windows-x64.zip`
+2. Extract the ZIP to any folder (e.g. `C:\Varda`)
+3. Run `varda.exe`
+
+No installer required. FFmpeg DLLs and shaders are bundled in the ZIP.
+
+> **Note:** Windows may show a SmartScreen warning because the binary is not code-signed. Click **"More info"** then **"Run anyway"**. You may also need the [Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) if it's not already installed (most Windows 10/11 systems have it).
 
 ## Workspace & Content
 
@@ -28,7 +58,34 @@ Shaders in `shaders/` appear automatically in the Library panel under **Generato
 | **HAP Video** | MOV with HAP, HAP Alpha, HAP Q, HAP Q Alpha, HAP R — GPU-native decode, no CPU overhead |
 | **Images** | PNG, JPG/JPEG |
 
-## Build & Run
+## Build from Source
+
+Requires [Rust](https://rustup.rs/) (stable) and a GPU with Metal (macOS), Vulkan (Linux), or DirectX 12 (Windows) support.
+
+### Ubuntu / Debian
+
+```bash
+sudo apt install build-essential cmake pkg-config libvulkan-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev libavdevice-dev libsrt-gnutls-dev libasound2-dev libv4l-dev libshaderc-dev libwayland-dev libxkbcommon-dev libx11-dev libxrandr-dev libxi-dev libgtk-3-dev
+```
+
+```bash
+cargo build --release
+./target/release/varda
+```
+
+### macOS
+
+```bash
+brew tap homebrew-ffmpeg/ffmpeg
+brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-srt
+```
+
+```bash
+cargo build --release
+./target/release/varda
+```
+
+### Run from source
 
 ```sh
 cargo run --release

--- a/docs/modulation.md
+++ b/docs/modulation.md
@@ -10,13 +10,13 @@ A low-frequency oscillator that cycles through a waveform continuously.
 
 | Setting | Range | Description |
 |---------|-------|-------------|
-| **Waveform** | Sine, Triangle, Sawtooth, Square, Random | Shape of the cycle |
+| **Waveform** | Sine, Triangle, Sawtooth, Square, Random, Smooth Random | Shape of the cycle |
 | **Frequency** | 0.01–10+ Hz | How fast the LFO cycles |
 | **Amplitude** | 0.0–1.0 | How wide the sweep is (fraction of parameter range) |
 | **Phase** | 0.0–1.0 | Offset in the cycle (0.5 = start halfway through) |
 | **Bipolar** | on/off | Off: output 0–1 (unipolar). On: output -1 to +1 (bipolar) |
 
-**Random** waveform produces sample-and-hold noise — a new random value each quarter-cycle, held constant until the next.
+**Random** waveform produces sample-and-hold noise — a new random value each quarter-cycle, held constant until the next. **Smooth Random** interpolates between random values for organic, non-repeating motion.
 
 ### Audio
 

--- a/docs/projection.md
+++ b/docs/projection.md
@@ -142,6 +142,28 @@ Real-time rotation applied in the GPU shader — does not recompute meshes:
 
 All three axes are **MIDI-mappable** for live performance. Rotation order: Roll → Elevation → Azimuth.
 
+### Surface Auto-Detection
+
+Import stage plans and auto-detect projection surfaces instead of drawing them manually. Varda supports three file types:
+
+| Format | Detection Method |
+|--------|-----------------|
+| **PNG / JPG** | Canny edge detection + contour tracing. Best for photos of venues or simple stage plan images. |
+| **SVG** | Path flattening — extracts shapes directly from vector paths. Best for designed floor plans. |
+| **DXF** | Geometric entity extraction (lines, polylines, circles, arcs, ellipses). Best for CAD venue plans. |
+
+**Workflow:**
+
+1. In the Stage Editor, click **Import** and select a file (PNG, JPG, SVG, or DXF)
+2. Varda detects contours and presents them as candidate surfaces
+3. Review and confirm — detected surfaces are added to the stage canvas
+
+Detection is configurable: edge thresholds, simplification tolerance, and minimum area can be adjusted. Small contours are filtered out, near-circular shapes are detected and created as circles, and surfaces are named by position (e.g., "Top-Left", "Center").
+
+This feature is also available via the HTTP API: `POST /api/stage/detect/image`, `/svg`, `/dxf`, and `POST /api/stage/detect/confirm`.
+
+---
+
 ### Mesh Import/Export
 
 | Format | Description |

--- a/docs/streaming-and-io.md
+++ b/docs/streaming-and-io.md
@@ -110,6 +110,40 @@ Recording uses non-blocking frame delivery — if the encoder can't keep up, fra
 
 ---
 
+## RTMP / RTMPS
+
+### Output (Streaming to Platforms)
+
+Push video directly to Twitch, YouTube, Kick, or any RTMP/RTMPS ingest endpoint — no OBS relay needed.
+
+1. Click **"+ Stream"** → select **RTMP**
+2. Enter the ingest URL (e.g., `rtmp://live.twitch.tv/app/<stream-key>` or `rtmps://a.rtmps.youtube.com/live2/<stream-key>`)
+3. Choose a codec: **H.264**, **H.265**, or **AV1** (H.265 and AV1 via Enhanced RTMP)
+4. Start the output
+
+Varda uses FLV muxing with auto-scaled CBR bitrate and 2-second keyframe intervals. Frame delivery is non-blocking.
+
+### Input (Receiving RTMP Streams)
+
+RTMP input supports two modes:
+
+**Pull mode** — connect to a remote RTMP stream:
+
+1. In the Library, open **📡 RTMP Sources** (under Stream Sources)
+2. Add a stream URL (e.g., `rtmp://192.168.1.50/live/stream`)
+3. **Drag** into a channel to create a live deck
+
+**Listen mode** — accept pushes from OBS, vMix, or other RTMP senders:
+
+1. In the Library, add an RTMP source and select **Listen** mode
+2. Varda generates a listen URL (starting at port 1935, incrementing for additional listeners)
+3. Configure OBS or other software to push to the generated URL
+4. **Drag** the source into a channel
+
+Stream sources are grouped under a single **Stream Sources** header in the Library panel. All stream source types (NDI, SRT, HLS, DASH, RTMP) share the same drag-to-channel workflow.
+
+---
+
 ## Syphon (macOS)
 
 Syphon enables inter-application GPU texture sharing on macOS. Varda includes framework detection and server discovery.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -264,13 +264,14 @@ impl VardaApp {
 
         // Prepare sub-mixes for any Channels(...) sources
         {
+            let mut seen: std::collections::HashSet<Vec<usize>> = std::collections::HashSet::new();
             let mut sub_mix_sources: Vec<Vec<usize>> = Vec::new();
             for surface in &self.output.surface_manager.surfaces {
                 if let OutputSource::Channels(indices) = &surface.source {
                     let mut sorted = indices.clone();
                     sorted.sort();
                     sorted.dedup();
-                    if !sub_mix_sources.contains(&sorted) {
+                    if seen.insert(sorted.clone()) {
                         sub_mix_sources.push(sorted);
                     }
                 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -156,14 +156,18 @@ impl VardaApp {
         // Compute effective channel opacities to determine which cameras are needed
         let channel_count = self.mixer.channel_count();
         let crossfader = self.mixer.crossfader();
-        let effective_opacities: Vec<f32> = if channel_count == 2 {
+        let two_ch_buf: [f32; 2];
+        let n_ch_buf: Vec<f32>;
+        let effective_opacities: &[f32] = if channel_count == 2 {
             let channels = self.mixer.channels();
-            vec![
+            two_ch_buf = [
                 (1.0 - crossfader) * channels[0].opacity,
                 crossfader * channels[1].opacity,
-            ]
+            ];
+            &two_ch_buf
         } else {
-            self.mixer.channels().iter().map(|ch| ch.opacity).collect()
+            n_ch_buf = self.mixer.channels().iter().map(|ch| ch.opacity).collect();
+            &n_ch_buf
         };
 
         // Collect camera IDs needed by visible channels

--- a/src/internal/audio/mod.rs
+++ b/src/internal/audio/mod.rs
@@ -128,6 +128,51 @@ impl AudioData {
     }
 }
 
+/// Compute the adaptive onset threshold from a window of spectral flux values.
+/// Returns `median(flux_history) * ONSET_THRESHOLD_MULTIPLIER + ONSET_THRESHOLD_OFFSET`.
+///
+/// Uses `select_nth_unstable_by` (quickselect, O(n)) instead of a full sort
+/// to find the median without allocating a new Vec.
+pub fn compute_onset_threshold(flux_history: &[f32]) -> f32 {
+    if flux_history.is_empty() {
+        return ONSET_THRESHOLD_OFFSET;
+    }
+    let mut buf = flux_history.to_vec();
+    let mid = buf.len() / 2;
+    buf.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap());
+    buf[mid] * ONSET_THRESHOLD_MULTIPLIER + ONSET_THRESHOLD_OFFSET
+}
+
+/// Estimate BPM from a history of beat intervals using median-based outlier rejection.
+/// Returns `None` if fewer than 4 intervals, or if the resulting BPM is outside 30-300.
+///
+/// Uses `select_nth_unstable_by` (quickselect, O(n)) for the median, then
+/// filters outliers using the original (unsorted) slice to avoid a second allocation.
+pub fn estimate_bpm(beat_intervals: &[f32]) -> Option<f32> {
+    if beat_intervals.len() < 4 {
+        return None;
+    }
+    let mut buf = beat_intervals.to_vec();
+    let mid = buf.len() / 2;
+    buf.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap());
+    let median = buf[mid];
+    // Filter outliers and compute average in a single pass — no intermediate Vec.
+    let (sum, count) = beat_intervals.iter().fold((0.0f32, 0u32), |(s, c), &iv| {
+        if (iv - median).abs() / median < TEMPO_TOLERANCE {
+            (s + iv, c + 1)
+        } else {
+            (s, c)
+        }
+    });
+    if count >= 2 {
+        let bpm = 60.0 / (sum / count as f32);
+        if (30.0..=300.0).contains(&bpm) {
+            return Some(bpm);
+        }
+    }
+    None
+}
+
 /// An active audio source with its own capture stream.
 struct ActiveAudioSource {
     _stream: cpal::Stream,
@@ -387,16 +432,7 @@ impl AudioManager {
                     if flux_history.len() > ONSET_MEDIAN_WINDOW {
                         flux_history.remove(0);
                     }
-                    let onset_threshold = {
-                        let mut sorted = flux_history.clone();
-                        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                        if sorted.is_empty() {
-                            ONSET_THRESHOLD_OFFSET
-                        } else {
-                            sorted[sorted.len() / 2] * ONSET_THRESHOLD_MULTIPLIER
-                                + ONSET_THRESHOLD_OFFSET
-                        }
-                    };
+                    let onset_threshold = compute_onset_threshold(&flux_history);
 
                     let now = Instant::now();
                     let elapsed = now.duration_since(last_beat_time).as_secs_f32();
@@ -410,22 +446,8 @@ impl AudioManager {
                             if beat_intervals.len() > BPM_HISTORY_SIZE {
                                 beat_intervals.remove(0);
                             }
-                            if beat_intervals.len() >= 4 {
-                                let mut sorted = beat_intervals.clone();
-                                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                                let median = sorted[sorted.len() / 2];
-                                let stable: Vec<f32> = beat_intervals
-                                    .iter()
-                                    .filter(|&&iv| (iv - median).abs() / median < TEMPO_TOLERANCE)
-                                    .copied()
-                                    .collect();
-                                if stable.len() >= 2 {
-                                    let avg = stable.iter().sum::<f32>() / stable.len() as f32;
-                                    let bpm = 60.0 / avg;
-                                    if (30.0..=300.0).contains(&bpm) {
-                                        current_bpm = Some(bpm);
-                                    }
-                                }
+                            if let Some(bpm) = estimate_bpm(&beat_intervals) {
+                                current_bpm = Some(bpm);
                             }
                         } else {
                             beat_intervals.clear();

--- a/src/internal/audio/mod.rs
+++ b/src/internal/audio/mod.rs
@@ -369,6 +369,9 @@ impl AudioManager {
         let mut prev_fft_magnitudes: Vec<f32> = vec![0.0; FFT_SIZE / 2];
         let mut flux_history: Vec<f32> = Vec::with_capacity(ONSET_MEDIAN_WINDOW + 1);
 
+        // Pre-allocated FFT input buffer (H4: avoid per-callback allocation)
+        let mut fft_input: Vec<Complex<f32>> = vec![Complex::new(0.0, 0.0); FFT_SIZE];
+
         // BPM detection state
         let mut last_beat_time = Instant::now();
         let mut beat_intervals: Vec<f32> = Vec::with_capacity(BPM_HISTORY_SIZE);
@@ -399,10 +402,10 @@ impl AudioManager {
                     ring_write_pos = (ring_write_pos + FFT_HOP) % FFT_SIZE;
 
                     // Extract linearized 2048-sample frame, apply Hann window
-                    let mut fft_input: Vec<Complex<f32>> = Vec::with_capacity(FFT_SIZE);
+                    // Reuse pre-allocated fft_input buffer (H4 optimisation)
                     for i in 0..FFT_SIZE {
                         let idx = (ring_write_pos + i) % FFT_SIZE;
-                        fft_input.push(Complex::new(ring_buffer[idx] * hann_window[i], 0.0));
+                        fft_input[i] = Complex::new(ring_buffer[idx] * hann_window[i], 0.0);
                     }
                     fft.process(&mut fft_input);
 

--- a/src/internal/channel/mod.rs
+++ b/src/internal/channel/mod.rs
@@ -638,9 +638,9 @@ impl Channel {
                         "progress",
                         crate::params::ParamValue::Float(progress as f32),
                     );
-                    let params_data = effect.params.build_buffer_data();
+                    effect.params.build_buffer_data();
                     if let Some(buf) = effect.params.buffer() {
-                        context.queue.write_buffer(buf, 0, &params_data);
+                        context.queue.write_buffer(buf, 0, effect.params.scratch());
                     }
 
                     let cmd = effect.pipeline.render_to_cmd(

--- a/src/internal/channel/mod.rs
+++ b/src/internal/channel/mod.rs
@@ -522,7 +522,7 @@ impl Channel {
         for (_deck_idx, slot) in self.decks.iter_mut().enumerate() {
             if !slot.mute && (!any_solo || slot.solo) && slot.opacity > 0.0 {
                 active_count += 1;
-                let param_prefix = format!("deck_{}", slot.deck.uuid());
+                let param_prefix = slot.deck.param_prefix().to_owned();
                 slot.deck.render_with_prefix(
                     context,
                     audio_data,
@@ -905,14 +905,12 @@ impl Channel {
                     (&self.effect_ping_view, &self.composite_view)
                 };
 
-                let fx_prefix = format!("fx_{}", effect.uuid);
                 if let Err(e) = effect.apply_with_modulation(
                     context,
                     input_view,
                     output_view,
                     &uniforms,
                     Some(modulation),
-                    Some(&fx_prefix),
                     &mut fx_cmd_buffers,
                 ) {
                     log::warn!("Effect {} failed, skipping: {}", _eff_idx, e);

--- a/src/internal/deck/effect.rs
+++ b/src/internal/deck/effect.rs
@@ -128,8 +128,12 @@ impl Effect {
         let params = ShaderParams::from_inputs(inputs);
         let phase_inputs_config = shader.metadata.phase_inputs.clone();
 
+        let uuid = crate::deck::generate_short_uuid();
+        let param_prefix = format!("fx_{}", uuid);
+
         Ok(Self {
-            uuid: crate::deck::generate_short_uuid(),
+            uuid,
+            param_prefix,
             shader,
             pipeline,
             enabled: true,
@@ -159,7 +163,6 @@ impl Effect {
             output_view,
             uniforms,
             None,
-            None,
             cmd_buffers,
         )
     }
@@ -172,7 +175,6 @@ impl Effect {
         output_view: &wgpu::TextureView,
         uniforms: &ISFUniforms,
         modulation: Option<&crate::modulation::ModulationEngine>,
-        mod_prefix: Option<&str>,
         cmd_buffers: &mut Vec<wgpu::CommandBuffer>,
     ) -> Result<()> {
         if !self.enabled {
@@ -182,8 +184,11 @@ impl Effect {
         // Ensure user params buffer exists and update it (with modulation if available)
         self.params.ensure_buffer(&context.device);
         if let Some(mod_engine) = modulation {
-            self.params
-                .update_buffer_with_modulation(&context.queue, mod_engine, mod_prefix);
+            self.params.update_buffer_with_modulation(
+                &context.queue,
+                mod_engine,
+                Some(&self.param_prefix),
+            );
         } else {
             self.params.update_buffer(&context.queue);
         }

--- a/src/internal/deck/mod.rs
+++ b/src/internal/deck/mod.rs
@@ -175,6 +175,8 @@ impl ExternalSourceKind {
 pub struct Effect {
     /// Stable UUID for this effect (8-char hex)
     pub uuid: String,
+    /// Cached "fx_{uuid}" prefix for modulation key lookups (avoids per-frame format!)
+    pub param_prefix: String,
     pub shader: ISFShader,
     pub pipeline: UnifiedPipeline,
     pub enabled: bool,
@@ -215,6 +217,9 @@ pub struct PassBuffer {
 pub struct Deck {
     /// Stable UUID for this deck (8-char hex, persists across moves/saves)
     uuid: String,
+
+    /// Cached "deck_{uuid}" prefix for modulation key lookups (avoids per-frame format!)
+    param_prefix: String,
 
     /// Name of this deck's source
     source_name: String,
@@ -275,8 +280,14 @@ impl Deck {
         &self.uuid
     }
 
+    /// Get the cached param prefix ("deck_{uuid}")
+    pub fn param_prefix(&self) -> &str {
+        &self.param_prefix
+    }
+
     /// Set the UUID (used during scene restore to preserve identity)
     pub fn set_uuid(&mut self, uuid: String) {
+        self.param_prefix = format!("deck_{}", uuid);
         self.uuid = uuid;
     }
 

--- a/src/internal/deck/render.rs
+++ b/src/internal/deck/render.rs
@@ -451,14 +451,12 @@ impl Deck {
             } else {
                 (&self.texture_view, &self.texture_b_view)
             };
-            let fx_prefix = format!("fx_{}", self.effects[effect_idx].uuid);
             self.effects[effect_idx].apply_with_modulation(
                 context,
                 input_view,
                 output_view,
                 &uniforms,
                 Some(modulation),
-                Some(&fx_prefix),
                 cmd_buffers,
             )?;
             read_from_b = !read_from_b;

--- a/src/internal/deck/source.rs
+++ b/src/internal/deck/source.rs
@@ -329,8 +329,12 @@ impl Deck {
             _ => None,
         };
 
+        let uuid = super::generate_short_uuid();
+        let param_prefix = format!("deck_{}", uuid);
+
         Ok(Self {
-            uuid: super::generate_short_uuid(),
+            uuid,
+            param_prefix,
             source_name,
             source_path,
             source,
@@ -742,8 +746,12 @@ impl Deck {
         let now = Instant::now();
         let generator_params = ShaderParams::from_inputs(&[]);
 
+        let uuid = super::generate_short_uuid();
+        let param_prefix = format!("deck_{}", uuid);
+
         Ok(Self {
-            uuid: super::generate_short_uuid(),
+            uuid,
+            param_prefix,
             source_name,
             source_path,
             source,

--- a/src/internal/mixer/render.rs
+++ b/src/internal/mixer/render.rs
@@ -4,6 +4,27 @@ use super::{AutoCrossfade, CrossfadeEasing, Mixer};
 use crate::renderer::{GpuContext, ISFUniforms};
 use anyhow::Result;
 
+/// Stack-friendly container for per-channel compositing opacities.
+///
+/// The common 2-channel case uses a fixed-size array on the stack, avoiding a
+/// heap allocation.  N-channel mode falls back to `Vec`.  Derefs to `&[f32]`
+/// so callers can use `.iter()`, `.get()`, indexing, etc. unchanged.
+enum CompositingOpacities {
+    Two([f32; 2]),
+    Many(Vec<f32>),
+}
+
+impl std::ops::Deref for CompositingOpacities {
+    type Target = [f32];
+
+    fn deref(&self) -> &[f32] {
+        match self {
+            CompositingOpacities::Two(arr) => arr,
+            CompositingOpacities::Many(vec) => vec,
+        }
+    }
+}
+
 impl Mixer {
     /// Pre-update modulation engine with latest audio data.
     pub fn update_modulation(&mut self, audio_values: &crate::modulation::AudioValues) {
@@ -79,15 +100,19 @@ impl Mixer {
         let time = self.start_time.elapsed().as_secs_f32();
         self.modulation.update(time, audio_values);
 
-        // Compute effective opacity per channel
+        // Compute effective opacity per channel (stack-allocated for the common 2-channel case)
         let channel_count = self.channels.len();
-        let effective_opacities: Vec<f32> = if channel_count == 2 {
-            vec![
+        let two_ch_buf: [f32; 2];
+        let n_ch_buf: Vec<f32>;
+        let effective_opacities: &[f32] = if channel_count == 2 {
+            two_ch_buf = [
                 (1.0 - self.crossfader) * self.channels[0].opacity,
                 self.crossfader * self.channels[1].opacity,
-            ]
+            ];
+            &two_ch_buf
         } else {
-            self.channels.iter().map(|ch| ch.opacity).collect()
+            n_ch_buf = self.channels.iter().map(|ch| ch.opacity).collect();
+            &n_ch_buf
         };
 
         // Always tick video frames on every channel so players stay in sync
@@ -467,11 +492,11 @@ impl Mixer {
     /// For 2-channel mode the first channel is always 1.0 (blitted at full
     /// opacity) and the crossfader value drives the second channel's composite
     /// weight.  For N-channel mode each channel uses its own opacity.
-    fn compositing_opacities(&self) -> Vec<f32> {
+    fn compositing_opacities(&self) -> CompositingOpacities {
         if self.channels.len() == 2 {
-            vec![1.0, self.crossfader]
+            CompositingOpacities::Two([1.0, self.crossfader])
         } else {
-            self.channels.iter().map(|ch| ch.opacity).collect()
+            CompositingOpacities::Many(self.channels.iter().map(|ch| ch.opacity).collect())
         }
     }
 

--- a/src/internal/mixer/render.rs
+++ b/src/internal/mixer/render.rs
@@ -177,7 +177,7 @@ impl Mixer {
 
         // If we have exactly 2 channels and a transition shader is active, use it
         if channel_count == 2 {
-            if let Some(transition) = &self.active_transition {
+            if let Some(transition) = &mut self.active_transition {
                 let width = self.composite_texture.width();
                 let height = self.composite_texture.height();
 
@@ -191,9 +191,11 @@ impl Mixer {
                     ..Default::default()
                 };
 
-                let params_data = transition.params.build_buffer_data();
+                transition.params.build_buffer_data();
                 if let Some(buf) = transition.params.buffer() {
-                    context.queue.write_buffer(buf, 0, &params_data);
+                    context
+                        .queue
+                        .write_buffer(buf, 0, transition.params.scratch());
                 }
 
                 transition.pipeline.render_to(

--- a/src/internal/mixer/render.rs
+++ b/src/internal/mixer/render.rs
@@ -111,14 +111,15 @@ impl Mixer {
         }
 
         self.sync_transition_progress();
-        self.composite_channels(context)?;
-        self.apply_master_effects(context, audio_data, time)?;
+        let composite_cmds = self.composite_channels(context)?;
+        self.apply_master_effects(context, audio_data, time, composite_cmds)?;
 
         self.frame_count += 1;
         Ok(())
     }
 
-    fn composite_channels(&mut self, context: &GpuContext) -> Result<()> {
+    fn composite_channels(&mut self, context: &GpuContext) -> Result<Vec<wgpu::CommandBuffer>> {
+        let mut cmd_buffers: Vec<wgpu::CommandBuffer> = Vec::new();
         let channel_count = self.channels.len();
         if channel_count == 0 {
             let mut encoder =
@@ -145,8 +146,8 @@ impl Mixer {
                     multiview_mask: None,
                 });
             }
-            context.queue.submit(std::iter::once(encoder.finish()));
-            return Ok(());
+            cmd_buffers.push(encoder.finish());
+            return Ok(cmd_buffers);
         }
 
         // If we have exactly 2 channels and a transition shader is active, use it
@@ -179,7 +180,7 @@ impl Mixer {
                     transition.params.buffer(),
                 );
 
-                return Ok(());
+                return Ok(Vec::new());
             }
         }
 
@@ -194,14 +195,9 @@ impl Mixer {
         // the crossfader value is used solely as the second channel's composite
         // opacity.  The composite shader performs `mix(dst, src, src_a)`, which
         // yields the correct linear crossfade: (1-cf)·A + cf·B.
-        let opacities: Vec<f32> = if channel_count == 2 {
-            vec![1.0, self.crossfader]
-        } else {
-            self.channels.iter().map(|ch| ch.opacity).collect()
-        };
+        let opacities = self.compositing_opacities();
 
-        // Submit per-channel to ensure each channel's uniform buffer writes
-        // are consumed before the next channel overwrites them.
+        // Batch channel compositing into command buffers for deferred submission.
         let mut is_first = true;
         for (_i, (channel, &opacity)) in self.channels.iter().zip(opacities.iter()).enumerate() {
             if opacity <= 0.0 {
@@ -239,7 +235,7 @@ impl Mixer {
                     });
                     self.blit_pipeline.render(&mut render_pass, &bind_group);
                 }
-                context.queue.submit(std::iter::once(encoder.finish()));
+                cmd_buffers.push(encoder.finish());
                 is_first = false;
             } else {
                 // Subsequent channels: snapshot + composite shader
@@ -294,13 +290,12 @@ impl Mixer {
                     self.composite_pipeline
                         .render(&mut render_pass, &bind_group);
                 }
-                context
-                    .queue
-                    .submit([copy_encoder.finish(), encoder.finish()]);
+                cmd_buffers.push(copy_encoder.finish());
+                cmd_buffers.push(encoder.finish());
             }
         }
 
-        Ok(())
+        Ok(cmd_buffers)
     }
 
     /// Prepare sub-mix textures for all unique multi-channel surface sources.
@@ -329,16 +324,9 @@ impl Mixer {
             None => return,
         };
 
-        let channel_count = self.channels.len();
-        // Same linear-crossfade formula as composite_channels (see comment there).
-        let opacities: Vec<f32> = if channel_count == 2 {
-            vec![1.0, self.crossfader]
-        } else {
-            self.channels.iter().map(|ch| ch.opacity).collect()
-        };
+        let opacities = self.compositing_opacities();
 
-        // Submit per-channel to ensure each channel's uniform buffer writes
-        // are consumed before the next channel overwrites them.
+        let mut cmd_buffers: Vec<wgpu::CommandBuffer> = Vec::new();
         let mut is_first = true;
         for &ch_idx in indices {
             if ch_idx >= self.channels.len() {
@@ -381,7 +369,7 @@ impl Mixer {
                     });
                     self.blit_pipeline.render(&mut render_pass, &bind_group);
                 }
-                context.queue.submit(std::iter::once(encoder.finish()));
+                cmd_buffers.push(encoder.finish());
                 is_first = false;
             } else {
                 // Subsequent channels: snapshot sub-mix → effect_ping, composite shader
@@ -436,9 +424,8 @@ impl Mixer {
                     self.composite_pipeline
                         .render(&mut render_pass, &bind_group);
                 }
-                context
-                    .queue
-                    .submit([copy_encoder.finish(), encoder.finish()]);
+                cmd_buffers.push(copy_encoder.finish());
+                cmd_buffers.push(encoder.finish());
             }
         }
 
@@ -467,7 +454,24 @@ impl Mixer {
                     multiview_mask: None,
                 });
             }
-            context.queue.submit(std::iter::once(encoder.finish()));
+            cmd_buffers.push(encoder.finish());
+        }
+
+        if !cmd_buffers.is_empty() {
+            context.queue.submit(cmd_buffers);
+        }
+    }
+
+    /// Compute per-channel compositing opacities.
+    ///
+    /// For 2-channel mode the first channel is always 1.0 (blitted at full
+    /// opacity) and the crossfader value drives the second channel's composite
+    /// weight.  For N-channel mode each channel uses its own opacity.
+    fn compositing_opacities(&self) -> Vec<f32> {
+        if self.channels.len() == 2 {
+            vec![1.0, self.crossfader]
+        } else {
+            self.channels.iter().map(|ch| ch.opacity).collect()
         }
     }
 
@@ -481,8 +485,12 @@ impl Mixer {
         context: &GpuContext,
         audio_data: &crate::audio::AudioData,
         time: f32,
+        mut cmd_buffers: Vec<wgpu::CommandBuffer>,
     ) -> Result<()> {
         if self.master_effects.is_empty() {
+            if !cmd_buffers.is_empty() {
+                context.queue.submit(cmd_buffers);
+            }
             return Ok(());
         }
 
@@ -506,7 +514,6 @@ impl Mixer {
         };
 
         let mut read_from_composite = true;
-        let mut cmd_buffers: Vec<wgpu::CommandBuffer> = Vec::new();
 
         for effect in self.master_effects.iter_mut() {
             if !effect.enabled {

--- a/src/internal/modulation/engine.rs
+++ b/src/internal/modulation/engine.rs
@@ -20,6 +20,15 @@ pub struct ModulationEngine {
     current_values: Vec<f32>,
     #[serde(skip)]
     prev_time: Option<f32>,
+    /// Cached topological evaluation order. Invalidated when assignments change.
+    #[serde(skip)]
+    cached_order: Vec<usize>,
+    /// Whether cached_order needs recomputation.
+    #[serde(skip)]
+    order_dirty: bool,
+    /// Per-source flag: does this source have any mod-on-mod assignments targeting it?
+    #[serde(skip)]
+    has_mod_on_mod: Vec<bool>,
 }
 
 impl ModulationEngine {
@@ -38,7 +47,13 @@ impl ModulationEngine {
     pub fn ensure_index(&mut self) {
         if self.uuid_to_idx.len() != self.sources.len() {
             self.rebuild_uuid_index();
+            self.invalidate_order();
         }
+    }
+
+    /// Mark the cached evaluation order as stale.
+    fn invalidate_order(&mut self) {
+        self.order_dirty = true;
     }
 
     /// Add a new source, returns its UUID
@@ -48,8 +63,10 @@ impl ModulationEngine {
         self.sources.push(entry);
         self.prev_values.push(0.0);
         self.current_values.push(0.0);
+        self.has_mod_on_mod.push(false);
         self.uuid_to_idx
             .insert(uuid.clone(), self.sources.len() - 1);
+        self.invalidate_order();
         uuid
     }
 
@@ -59,8 +76,10 @@ impl ModulationEngine {
         self.sources.push(entry);
         self.prev_values.push(0.0);
         self.current_values.push(0.0);
+        self.has_mod_on_mod.push(false);
         self.uuid_to_idx
             .insert(uuid.clone(), self.sources.len() - 1);
+        self.invalidate_order();
         uuid
     }
 
@@ -74,6 +93,9 @@ impl ModulationEngine {
             if idx < self.current_values.len() {
                 self.current_values.remove(idx);
             }
+            if idx < self.has_mod_on_mod.len() {
+                self.has_mod_on_mod.remove(idx);
+            }
             // Remove assignments referencing this source (no reindexing needed)
             for mods in self.assignments.values_mut() {
                 mods.retain(|m| m.source_id != uuid);
@@ -82,6 +104,7 @@ impl ModulationEngine {
             let mod_prefix = format!("mod:{}:", uuid);
             self.assignments.retain(|k, _| !k.starts_with(&mod_prefix));
             self.rebuild_uuid_index();
+            self.invalidate_order();
         }
     }
 
@@ -92,6 +115,7 @@ impl ModulationEngine {
         self.assignments.retain(|k, _| !k.starts_with(prefix));
         let removed = before - self.assignments.len();
         if removed > 0 {
+            self.invalidate_order();
             log::info!(
                 "Removed {} orphaned modulation assignments with prefix '{}'",
                 removed,
@@ -122,6 +146,7 @@ impl ModulationEngine {
             .entry(param_name.to_string())
             .or_default()
             .push(modulation);
+        self.invalidate_order();
     }
 
     pub fn assign_mod_on_mod(
@@ -133,15 +158,18 @@ impl ModulationEngine {
     ) {
         let key = format!("mod:{}:{}", target_uuid, param_name);
         self.assign(&key, modulator_uuid, amount, None);
+        // assign() already calls invalidate_order()
     }
 
     pub fn clear_mod_on_mod(&mut self, target_uuid: &str, param_name: &str) {
         let key = format!("mod:{}:{}", target_uuid, param_name);
         self.assignments.remove(&key);
+        self.invalidate_order();
     }
 
     pub fn clear_assignments(&mut self, param_name: &str) {
         self.assignments.remove(param_name);
+        self.invalidate_order();
     }
 
     pub fn trigger_adsr(&mut self, uuid: &str) {
@@ -170,13 +198,32 @@ impl ModulationEngine {
         self.sources.iter().any(|e| e.uuid == uuid)
     }
 
-    fn source_idx(&self, uuid: &str) -> Option<usize> {
-        self.sources.iter().position(|e| e.uuid == uuid)
-    }
-
     fn get_mod_source_offset(&self, source_uuid: &str, param_name: &str) -> f32 {
-        let key = format!("mod:{}:{}", source_uuid, param_name);
-        self.get_modulation(&key)
+        // Look up "mod:{uuid}:{param}" without allocating a String.
+        // We scan assignments for keys matching this pattern.
+        let prefix = "mod:";
+        for (key, mods) in &self.assignments {
+            if key.starts_with(prefix)
+                && key[prefix.len()..].starts_with(source_uuid)
+                && key.len() > prefix.len() + source_uuid.len()
+                && key.as_bytes()[prefix.len() + source_uuid.len()] == b':'
+                && &key[prefix.len() + source_uuid.len() + 1..] == param_name
+            {
+                let mut total = 0.0;
+                for m in mods {
+                    let idx = if let Some(&i) = self.uuid_to_idx.get(&m.source_id) {
+                        i
+                    } else {
+                        continue;
+                    };
+                    if idx < self.current_values.len() {
+                        total += self.current_values[idx] * m.amount;
+                    }
+                }
+                return total;
+            }
+        }
+        0.0
     }
 
     fn apply_mod_on_mod(&self, idx: usize, source: &ModulationSource) -> ModulationSource {
@@ -221,19 +268,30 @@ impl ModulationEngine {
         modified
     }
 
-    pub(crate) fn evaluation_order(&self) -> Vec<usize> {
+    /// Recompute the cached evaluation order and per-source mod-on-mod flags.
+    fn recompute_order(&mut self) {
         const MAX_MOD_DEPTH: usize = 4;
         let n = self.sources.len();
+
+        // Rebuild has_mod_on_mod flags
+        self.has_mod_on_mod.clear();
+        self.has_mod_on_mod.resize(n, false);
+
+        self.cached_order.clear();
         if n == 0 {
-            return vec![];
+            self.order_dirty = false;
+            return;
         }
 
         let mut deps: Vec<Vec<usize>> = vec![Vec::new(); n];
         for (key, mods) in &self.assignments {
             if let Some(target_uuid) = Self::parse_mod_target(key) {
-                if let Some(target_idx) = self.source_idx(target_uuid) {
+                if let Some(&target_idx) = self.uuid_to_idx.get(target_uuid) {
+                    if target_idx < n {
+                        self.has_mod_on_mod[target_idx] = true;
+                    }
                     for m in mods {
-                        if let Some(src_idx) = self.source_idx(&m.source_id) {
+                        if let Some(&src_idx) = self.uuid_to_idx.get(&m.source_id) {
                             if src_idx != target_idx {
                                 deps[target_idx].push(src_idx);
                             }
@@ -243,7 +301,7 @@ impl ModulationEngine {
             }
         }
 
-        let mut order = Vec::with_capacity(n);
+        self.cached_order.reserve(n);
         let mut evaluated = vec![false; n];
         for _pass in 0..MAX_MOD_DEPTH {
             let mut progress = false;
@@ -252,7 +310,7 @@ impl ModulationEngine {
                     continue;
                 }
                 if deps[i].iter().all(|&d| evaluated[d]) {
-                    order.push(i);
+                    self.cached_order.push(i);
                     evaluated[i] = true;
                     progress = true;
                 }
@@ -263,20 +321,33 @@ impl ModulationEngine {
         }
         for i in 0..n {
             if !evaluated[i] {
-                order.push(i);
+                self.cached_order.push(i);
             }
         }
-        order
+        self.order_dirty = false;
+    }
+
+    /// Get the evaluation order, recomputing if stale. Used by tests.
+    #[cfg(test)]
+    pub(crate) fn evaluation_order(&mut self) -> Vec<usize> {
+        if self.order_dirty {
+            self.recompute_order();
+        }
+        self.cached_order.clone()
     }
 
     /// Parse mod-on-mod key: "mod:{uuid}:{param}" → Some(uuid)
     pub(crate) fn parse_mod_target(key: &str) -> Option<&str> {
-        let parts: Vec<&str> = key.splitn(3, ':').collect();
-        if parts.len() >= 2 && parts[0] == "mod" {
-            Some(parts[1])
-        } else {
-            None
+        // Avoid allocating a Vec for splitn — just find the delimiters.
+        let key = key.as_bytes();
+        if key.len() < 5 || &key[..4] != b"mod:" {
+            return None;
         }
+        let rest = &key[4..];
+        // Find the next ':' separating uuid from param_name
+        rest.iter()
+            .position(|&b| b == b':')
+            .map(|pos| std::str::from_utf8(&rest[..pos]).unwrap_or(""))
     }
 
     /// Update all source values for the current frame
@@ -292,14 +363,22 @@ impl ModulationEngine {
             self.current_values.push(0.0);
         }
 
-        let order = self.evaluation_order();
-        for i in order {
-            let mut effective = self.apply_mod_on_mod(i, &self.sources[i].source);
-            let value = effective.calculate(time, dt, audio, self.prev_values[i]);
+        if self.order_dirty {
+            self.recompute_order();
+        }
 
-            // Copy back mutable state changes (ADSR stage progression)
-            match (&mut self.sources[i].source, &effective) {
-                (
+        // Iterate over cached order (clone the slice to avoid borrow conflict)
+        let order_len = self.cached_order.len();
+        for oi in 0..order_len {
+            let i = self.cached_order[oi];
+
+            // Only clone + apply mod-on-mod if this source actually has mod-on-mod assignments
+            let value = if i < self.has_mod_on_mod.len() && self.has_mod_on_mod[i] {
+                let mut effective = self.apply_mod_on_mod(i, &self.sources[i].source);
+                let v = effective.calculate(time, dt, audio, self.prev_values[i]);
+
+                // Copy back mutable state changes (ADSR stage progression)
+                if let (
                     ModulationSource::ADSR {
                         stage,
                         stage_time,
@@ -312,13 +391,19 @@ impl ModulationEngine {
                         current_level: eff_cl,
                         ..
                     },
-                ) => {
+                ) = (&mut self.sources[i].source, &effective)
+                {
                     *stage = *eff_stage;
                     *stage_time = *eff_st;
                     *current_level = *eff_cl;
                 }
-                _ => {}
-            }
+                v
+            } else {
+                // No mod-on-mod: calculate directly on the source (no clone)
+                self.sources[i]
+                    .source
+                    .calculate(time, dt, audio, self.prev_values[i])
+            };
 
             self.current_values[i] = value;
             self.prev_values[i] = value;

--- a/src/internal/modulation/sources.rs
+++ b/src/internal/modulation/sources.rs
@@ -388,7 +388,9 @@ impl ModulationSource {
                 }
                 let total_steps = steps.len() as f32;
                 let position = (time * *rate) % total_steps;
-                let current_idx = position.floor() as usize % steps.len();
+                // position is already in [0, total_steps) after the modulo above,
+                // so truncation to usize is bounded by [0, steps.len()-1].
+                let current_idx = position as usize;
                 let raw = match interpolation {
                     StepInterpolation::None => steps[current_idx],
                     StepInterpolation::Linear => {

--- a/src/internal/params/mod.rs
+++ b/src/internal/params/mod.rs
@@ -123,6 +123,8 @@ pub struct ShaderParams {
     /// Reusable scratch buffer for serialization (avoids per-frame heap allocation).
     /// Capacity stabilises after the first frame at `buffer_size()`.
     scratch: Vec<u8>,
+    /// Reusable scratch string for modulation key construction (avoids per-param allocation).
+    mod_key_scratch: String,
 }
 
 impl ShaderParams {
@@ -151,6 +153,7 @@ impl ShaderParams {
             buffer: None,
             dirty: true,
             scratch: Vec::new(),
+            mod_key_scratch: String::new(),
         }
     }
 
@@ -363,7 +366,8 @@ impl ShaderParams {
         self.scratch.clear();
         self.scratch.reserve(self.buffer_size());
 
-        for name in &self.param_order {
+        for idx in 0..self.param_order.len() {
+            let name = &self.param_order[idx];
             if let Some(value) = self.values.get(name) {
                 let alignment = match value {
                     ParamValue::Float(_) | ParamValue::Bool(_) | ParamValue::Long(_) => 4,
@@ -374,8 +378,20 @@ impl ShaderParams {
                     self.scratch.push(0);
                 }
 
-                let modulated =
-                    self.apply_modulation_to_value(name, value, modulation, param_prefix);
+                // Build modulation key in reusable scratch string (zero alloc after first frame)
+                self.mod_key_scratch.clear();
+                if let Some(prefix) = param_prefix {
+                    self.mod_key_scratch.push_str(prefix);
+                    self.mod_key_scratch.push(':');
+                }
+                self.mod_key_scratch.push_str(name);
+
+                let modulated = Self::apply_modulation_to_value_with_key(
+                    &self.mod_key_scratch,
+                    value,
+                    modulation,
+                    self.definitions.get(name.as_str()),
+                );
                 modulated.write_bytes(&mut self.scratch);
             }
         }
@@ -388,31 +404,19 @@ impl ShaderParams {
         &self.scratch
     }
 
-    /// Apply modulation to a parameter value
-    /// `param_prefix` is used to look up modulation (e.g., "deck0" to look up "deck0:paramname")
-    fn apply_modulation_to_value(
-        &self,
-        name: &str,
+    /// Apply modulation to a parameter value using a pre-built modulation key.
+    fn apply_modulation_to_value_with_key(
+        mod_key: &str,
         value: &ParamValue,
         modulation: &ModulationEngine,
-        param_prefix: Option<&str>,
+        definition: Option<&ISFInput>,
     ) -> ParamValue {
-        // Get min/max from definition for clamping
-        let definition = self.definitions.get(name);
-
-        // Build the full modulation key
-        let mod_key = match param_prefix {
-            Some(prefix) => format!("{}:{}", prefix, name),
-            None => name.to_string(),
-        };
-
         match value {
             ParamValue::Float(base) => {
-                let offset = modulation.get_modulation(&mod_key);
+                let offset = modulation.get_modulation(mod_key);
                 if offset == 0.0 {
                     return *value;
                 }
-                // Get range from definition
                 let (min_val, max_val) = definition
                     .map(|d| {
                         let min = d.min.unwrap_or(0.0);
@@ -427,7 +431,7 @@ impl ShaderParams {
             ParamValue::Color(base) => {
                 let mut result = *base;
                 for i in 0..4 {
-                    let offset = modulation.get_modulation_for_component(&mod_key, Some(i));
+                    let offset = modulation.get_modulation_for_component(mod_key, Some(i));
                     if offset != 0.0 {
                         result[i] = (result[i] + offset).clamp(0.0, 1.0);
                     }
@@ -437,14 +441,13 @@ impl ShaderParams {
             ParamValue::Point2D(base) => {
                 let mut result = *base;
                 for i in 0..2 {
-                    let offset = modulation.get_modulation_for_component(&mod_key, Some(i));
+                    let offset = modulation.get_modulation_for_component(mod_key, Some(i));
                     if offset != 0.0 {
-                        result[i] = result[i] + offset; // Point2D can be unbounded
+                        result[i] = result[i] + offset;
                     }
                 }
                 ParamValue::Point2D(result)
             }
-            // Bool and Long don't support continuous modulation
             _ => *value,
         }
     }

--- a/src/internal/params/mod.rs
+++ b/src/internal/params/mod.rs
@@ -120,6 +120,9 @@ pub struct ShaderParams {
     buffer: Option<wgpu::Buffer>,
     /// Buffer needs re-upload
     dirty: bool,
+    /// Reusable scratch buffer for serialization (avoids per-frame heap allocation).
+    /// Capacity stabilises after the first frame at `buffer_size()`.
+    scratch: Vec<u8>,
 }
 
 impl ShaderParams {
@@ -147,6 +150,7 @@ impl ShaderParams {
             definitions,
             buffer: None,
             dirty: true,
+            scratch: Vec::new(),
         }
     }
 
@@ -255,42 +259,39 @@ impl ShaderParams {
         (size.max(16) + 15) & !15
     }
 
-    /// Build byte buffer for GPU upload (respects std140 alignment rules)
-    pub fn build_buffer_data(&self) -> Vec<u8> {
-        let mut data = Vec::with_capacity(self.buffer_size());
+    /// Serialize parameter values into the reusable scratch buffer (std140 layout).
+    /// Returns a slice valid until the next `build_*` or mutable call.
+    /// After the first call the scratch capacity stabilises — zero heap allocation
+    /// on subsequent frames.
+    pub fn build_buffer_data(&mut self) -> &[u8] {
+        self.scratch.clear();
+        self.scratch.reserve(self.buffer_size());
         for name in &self.param_order {
             if let Some(value) = self.values.get(name) {
-                // std140 alignment rules:
-                // - float, bool, int: 4-byte alignment
-                // - vec2: 8-byte alignment
-                // - vec3, vec4: 16-byte alignment
                 let alignment = match value {
                     ParamValue::Float(_) | ParamValue::Bool(_) | ParamValue::Long(_) => 4,
                     ParamValue::Point2D(_) => 8,
                     ParamValue::Color(_) => 16,
                 };
-                // Pad to required alignment
-                while data.len() % alignment != 0 {
-                    data.push(0);
+                while self.scratch.len() % alignment != 0 {
+                    self.scratch.push(0);
                 }
-                value.write_bytes(&mut data);
+                value.write_bytes(&mut self.scratch);
             }
         }
-        // Pad to minimum 16 bytes
-        while data.len() < 16 {
-            data.push(0);
+        while self.scratch.len() < 16 {
+            self.scratch.push(0);
         }
-        // Align to 16 bytes (uniform buffer requirement)
-        while data.len() % 16 != 0 {
-            data.push(0);
+        while self.scratch.len() % 16 != 0 {
+            self.scratch.push(0);
         }
-        data
+        &self.scratch
     }
 
     /// Create or get GPU buffer
     pub fn ensure_buffer(&mut self, device: &wgpu::Device) -> &wgpu::Buffer {
         if self.buffer.is_none() {
-            let data = self.build_buffer_data();
+            let data = self.build_buffer_data().to_vec();
             self.buffer = Some(
                 device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some("Shader Params Buffer"),
@@ -308,17 +309,24 @@ impl ShaderParams {
     /// Update GPU buffer if dirty
     pub fn update_buffer(&mut self, queue: &wgpu::Queue) {
         if self.dirty {
+            // Reborrow: build into scratch, then write to GPU buffer.
+            self.build_buffer_data();
             if let Some(buffer) = &self.buffer {
-                let data = self.build_buffer_data();
-                queue.write_buffer(buffer, 0, &data);
-                self.dirty = false;
+                queue.write_buffer(buffer, 0, &self.scratch);
             }
+            self.dirty = false;
         }
     }
 
     /// Get the buffer reference (panics if not created)
     pub fn buffer(&self) -> Option<&wgpu::Buffer> {
         self.buffer.as_ref()
+    }
+
+    /// Read-only access to the last serialized scratch data.
+    /// Valid after a `build_buffer_data` or `build_modulated_buffer_data` call.
+    pub fn scratch(&self) -> &[u8] {
+        &self.scratch
     }
 
     /// Mark as needing re-upload
@@ -345,44 +353,39 @@ impl ShaderParams {
         self.dirty = true;
     }
 
-    /// Build byte buffer with modulation applied
-    /// This creates a temporary modulated value for GPU upload without modifying base values
-    /// `param_prefix` is used to look up modulation (e.g., "deck0" to look up "deck0:paramname")
+    /// Serialize parameter values with modulation applied into the reusable scratch buffer.
+    /// Returns a slice valid until the next `build_*` or mutable call.
     pub fn build_modulated_buffer_data(
-        &self,
+        &mut self,
         modulation: &ModulationEngine,
         param_prefix: Option<&str>,
-    ) -> Vec<u8> {
-        let mut data = Vec::with_capacity(self.buffer_size());
+    ) -> &[u8] {
+        self.scratch.clear();
+        self.scratch.reserve(self.buffer_size());
 
         for name in &self.param_order {
             if let Some(value) = self.values.get(name) {
-                // std140 alignment rules
                 let alignment = match value {
                     ParamValue::Float(_) | ParamValue::Bool(_) | ParamValue::Long(_) => 4,
                     ParamValue::Point2D(_) => 8,
                     ParamValue::Color(_) => 16,
                 };
-                // Pad to required alignment
-                while data.len() % alignment != 0 {
-                    data.push(0);
+                while self.scratch.len() % alignment != 0 {
+                    self.scratch.push(0);
                 }
 
-                // Apply modulation and write
                 let modulated =
                     self.apply_modulation_to_value(name, value, modulation, param_prefix);
-                modulated.write_bytes(&mut data);
+                modulated.write_bytes(&mut self.scratch);
             }
         }
-        // Pad to minimum 16 bytes
-        while data.len() < 16 {
-            data.push(0);
+        while self.scratch.len() < 16 {
+            self.scratch.push(0);
         }
-        // Align to 16 bytes (uniform buffer requirement)
-        while data.len() % 16 != 0 {
-            data.push(0);
+        while self.scratch.len() % 16 != 0 {
+            self.scratch.push(0);
         }
-        data
+        &self.scratch
     }
 
     /// Apply modulation to a parameter value
@@ -454,9 +457,10 @@ impl ShaderParams {
         modulation: &ModulationEngine,
         param_prefix: Option<&str>,
     ) {
+        // Build into scratch first, then write to GPU buffer.
+        self.build_modulated_buffer_data(modulation, param_prefix);
         if let Some(buffer) = &self.buffer {
-            let data = self.build_modulated_buffer_data(modulation, param_prefix);
-            queue.write_buffer(buffer, 0, &data);
+            queue.write_buffer(buffer, 0, &self.scratch);
         }
         // Note: we don't clear dirty flag here since base values may have changed
     }
@@ -750,7 +754,7 @@ mod tests {
             make_float_input("brightness", 0.5, 0.0, 1.0),
             make_bool_input("invert", true),
         ];
-        let params = ShaderParams::from_inputs(&inputs);
+        let mut params = ShaderParams::from_inputs(&inputs);
         let data = params.build_buffer_data();
         assert!(data.len() >= 16);
         assert_eq!(data.len() % 16, 0);
@@ -777,17 +781,17 @@ mod tests {
     #[test]
     fn shader_params_modulated_buffer_no_modulation() {
         let inputs = vec![make_float_input("brightness", 0.5, 0.0, 1.0)];
-        let params = ShaderParams::from_inputs(&inputs);
+        let mut params = ShaderParams::from_inputs(&inputs);
         let engine = ModulationEngine::new();
-        let data = params.build_modulated_buffer_data(&engine, None);
-        let base = params.build_buffer_data();
+        let data = params.build_modulated_buffer_data(&engine, None).to_vec();
+        let base = params.build_buffer_data().to_vec();
         assert_eq!(data, base, "No modulation should produce identical buffer");
     }
 
     #[test]
     fn shader_params_modulated_buffer_with_modulation() {
         let inputs = vec![make_float_input("brightness", 0.5, 0.0, 1.0)];
-        let params = ShaderParams::from_inputs(&inputs);
+        let mut params = ShaderParams::from_inputs(&inputs);
         let mut engine = ModulationEngine::new();
         let uuid = engine.add_source(crate::modulation::ModulationSource::LFO {
             waveform: crate::modulation::LFOWaveform::Sine,
@@ -799,8 +803,8 @@ mod tests {
         engine.update(0.25, &crate::modulation::AudioValues::default());
         engine.assign("brightness", &uuid, 0.5, None);
 
-        let modulated = params.build_modulated_buffer_data(&engine, None);
-        let base = params.build_buffer_data();
+        let modulated = params.build_modulated_buffer_data(&engine, None).to_vec();
+        let base = params.build_buffer_data().to_vec();
         // Modulated should differ from base (LFO at t=0.25 is non-zero)
         assert_ne!(modulated, base, "Modulated buffer should differ from base");
     }
@@ -808,15 +812,17 @@ mod tests {
     #[test]
     fn shader_params_modulated_with_prefix() {
         let inputs = vec![make_float_input("brightness", 0.5, 0.0, 1.0)];
-        let params = ShaderParams::from_inputs(&inputs);
+        let mut params = ShaderParams::from_inputs(&inputs);
         let mut engine = ModulationEngine::new();
         let uuid = engine.add_source(crate::modulation::ModulationSource::sine_lfo(1.0));
         engine.update(0.25, &crate::modulation::AudioValues::default());
         // Assign with prefix "deck0:brightness"
         engine.assign("deck0:brightness", &uuid, 0.5, None);
 
-        let modulated = params.build_modulated_buffer_data(&engine, Some("deck0"));
-        let base = params.build_buffer_data();
+        let modulated = params
+            .build_modulated_buffer_data(&engine, Some("deck0"))
+            .to_vec();
+        let base = params.build_buffer_data().to_vec();
         assert_ne!(modulated, base, "Prefixed modulation should apply");
     }
 
@@ -827,7 +833,7 @@ mod tests {
             make_float_input("a", 1.0, 0.0, 1.0), // 4 bytes at offset 0
             make_point2d_input("center"),         // should align to offset 8
         ];
-        let params = ShaderParams::from_inputs(&inputs);
+        let mut params = ShaderParams::from_inputs(&inputs);
         let data = params.build_buffer_data();
         // offset 0..4: float a
         // offset 4..8: padding (align to 8 for vec2)
@@ -846,7 +852,7 @@ mod tests {
             make_float_input("a", 1.0, 0.0, 1.0), // 4 bytes at offset 0
             make_color_input("tint"),             // should align to offset 16
         ];
-        let params = ShaderParams::from_inputs(&inputs);
+        let mut params = ShaderParams::from_inputs(&inputs);
         let data = params.build_buffer_data();
         assert!(data.len() >= 32);
         // tint starts at offset 16


### PR DESCRIPTION

Various performance optimizations:

Batch GPU command encoding in mixer compositing pipeline by reducing per-frame queue.submit() calls. uses batching command encoders across the mixer compositing stages. Instead of submitting per-channel command buffers are collected into a Vec and submitted once.

Audio callback Vec clones for median computation. Extracted benchable audio functions. Replaced full sort with `select_nth_unstable_by`.  remove intermediate `stable: Vec<f32>` in `estimate_bpm` with a single-pass fold.

fix Per-frame format!() allocation in modulator uuids

use fixed size arrays instead of Vecs where possible to reduce allocation churn

added scratch: Vec<u8> field to ShaderParams. Changed build_buffer_data and build_modulated_buffer_data to &mut self, clearing and reusing the scratch buffer.

skip clone when no mod-on-mod. eliminated the unconditional ModulationSource::clone() for every source every frame

cached modulation eval order. eliminated O(n²) topological sort recomputation every frame

| Benchmark | main | perf-opts | Change |
|-----------|------|-----------|--------|
| `no_mod/4` | 125.8 ns | 104.1 ns | **-16.7%** |
| `empty_mod/4` | 345.7 ns | 199.7 ns | **-42.5%** |
| `active_lfo/4` | 459.4 ns | 272.6 ns | **-40.4%** |
| `no_mod/8` | 226.9 ns | 201.0 ns | **-10.9%** |
| `empty_mod/8` | 608.8 ns | 372.7 ns | **-39.9%** |
| `active_lfo/8` | 767.0 ns | 479.9 ns | **-37.8%** |
| `no_mod/16` | 417.1 ns | 387.0 ns | **-7.2%** |
| `empty_mod/16` | 1.216 µs | 718.8 ns | **-40.5%** |
| `active_lfo/16` | 1.456 µs | 920.2 ns | **-37.2%** |
