### PR TITLE
#42 PERF: eliminate per-frame buffer allocations in compositing pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,3 +106,7 @@ lto = "thin"
 codegen-units = 1
 strip = "symbols"
 panic = "abort"
+
+[profile.bench]
+debug = true
+strip = "none"

--- a/benches/compositing.rs
+++ b/benches/compositing.rs
@@ -18,7 +18,11 @@ use std::time::Instant;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use varda::{
-    audio::AudioData, deck::Deck, isf::ISFShader, mixer::Mixer, modulation::AudioValues,
+    audio::AudioData,
+    deck::Deck,
+    isf::ISFShader,
+    mixer::Mixer,
+    modulation::{AnalyzerValues, AudioValues},
     renderer::context::GpuContext,
 };
 
@@ -72,14 +76,19 @@ fn time_render_us(ctx: &GpuContext, mixer: &mut Mixer, samples: usize) -> u128 {
     let audio_values = AudioValues {
         sources: Default::default(),
     };
+    let analyzer_values = AnalyzerValues::default();
     for _ in 0..3 {
-        mixer.render(ctx, &audio, &audio_values).expect("warmup");
+        mixer
+            .render(ctx, &audio, &audio_values, &analyzer_values)
+            .expect("warmup");
         poll(ctx);
     }
     let mut times = Vec::with_capacity(samples);
     for _ in 0..samples {
         let t0 = Instant::now();
-        mixer.render(ctx, &audio, &audio_values).expect("render");
+        mixer
+            .render(ctx, &audio, &audio_values, &analyzer_values)
+            .expect("render");
         poll(ctx);
         times.push(t0.elapsed().as_micros());
     }
@@ -115,6 +124,7 @@ fn bench_channel_composite_solid(c: &mut Criterion) {
     let audio_values = AudioValues {
         sources: Default::default(),
     };
+    let analyzer_values = AnalyzerValues::default();
 
     let mut group = c.benchmark_group("channel_composite_solid");
     group.sample_size(50);
@@ -123,7 +133,9 @@ fn bench_channel_composite_solid(c: &mut Criterion) {
         let mut mixer = setup_mixer_solid(&ctx, n_decks);
         group.bench_with_input(BenchmarkId::new("decks", n_decks), &n_decks, |b, _| {
             b.iter(|| {
-                mixer.render(&ctx, &audio, &audio_values).expect("render");
+                mixer
+                    .render(&ctx, &audio, &audio_values, &analyzer_values)
+                    .expect("render");
                 poll(&ctx);
             });
         });
@@ -142,6 +154,7 @@ fn bench_channel_composite_shader(c: &mut Criterion) {
     let audio_values = AudioValues {
         sources: Default::default(),
     };
+    let analyzer_values = AnalyzerValues::default();
 
     let mut group = c.benchmark_group("channel_composite_shader");
     group.sample_size(50);
@@ -150,7 +163,9 @@ fn bench_channel_composite_shader(c: &mut Criterion) {
         let mut mixer = setup_mixer_shader(&ctx, n_decks);
         group.bench_with_input(BenchmarkId::new("decks", n_decks), &n_decks, |b, _| {
             b.iter(|| {
-                mixer.render(&ctx, &audio, &audio_values).expect("render");
+                mixer
+                    .render(&ctx, &audio, &audio_values, &analyzer_values)
+                    .expect("render");
                 poll(&ctx);
             });
         });
@@ -169,6 +184,7 @@ fn bench_mixer_crossfade(c: &mut Criterion) {
     let audio_values = AudioValues {
         sources: Default::default(),
     };
+    let analyzer_values = AnalyzerValues::default();
 
     let mut mixer = setup_mixer_solid(&ctx, 1);
     let deck =
@@ -180,7 +196,9 @@ fn bench_mixer_crossfade(c: &mut Criterion) {
     group.sample_size(50);
     group.bench_function("2ch_50pct", |b| {
         b.iter(|| {
-            mixer.render(&ctx, &audio, &audio_values).expect("render");
+            mixer
+                .render(&ctx, &audio, &audio_values, &analyzer_values)
+                .expect("render");
             poll(&ctx);
         });
     });

--- a/src/internal/channel/mod.rs
+++ b/src/internal/channel/mod.rs
@@ -597,10 +597,13 @@ impl Channel {
             .collect();
 
         // Composite all decks to the composite texture.
-        // Submit per-deck to ensure each deck's uniform buffer writes
-        // are consumed before the next deck overwrites them.
+        // Per-draw params are written into a persistent ring buffer (one slot per
+        // deck) so all command buffers can batch into a single queue.submit().
+        // This eliminates N-1 submit calls per channel — critical for Intel
+        // integrated GPUs where each Metal command buffer commit is expensive.
         let width = self.composite_texture.width();
         let height = self.composite_texture.height();
+        let mut composite_cmds: Vec<wgpu::CommandBuffer> = Vec::new();
 
         for (i, info) in ordered.iter().enumerate() {
             let slot = &mut self.decks[info.deck_idx];
@@ -620,7 +623,7 @@ impl Channel {
                         self.effect_ping_texture.as_image_copy(),
                         self.composite_texture.size(),
                     );
-                    context.queue.submit(std::iter::once(copy_encoder.finish()));
+                    composite_cmds.push(copy_encoder.finish());
 
                     // Run transition shader: start=deck (outgoing), end=composite-below (incoming)
                     let uniforms = ISFUniforms {
@@ -651,7 +654,7 @@ impl Channel {
                         &uniforms,
                         effect.params.buffer(),
                     );
-                    context.queue.submit(std::iter::once(cmd));
+                    composite_cmds.push(cmd);
                     continue;
                 }
 
@@ -659,10 +662,18 @@ impl Channel {
                 let fade_opacity = info.opacity * (1.0 - progress as f32);
                 if i == 0 {
                     // First deck: simple blit with alpha blending
-                    self.blit_pipeline.set_opacity(&context.queue, fade_opacity);
-                    let bind_group = self
-                        .blit_pipeline
-                        .create_bind_group(&context.device, &slot.deck.texture_view);
+                    self.blit_pipeline.write_params_slot(
+                        &context.queue,
+                        i,
+                        fade_opacity,
+                        [1.0, 1.0],
+                        [0.0, 0.0],
+                    );
+                    let bind_group = self.blit_pipeline.create_ring_bind_group(
+                        &context.device,
+                        &slot.deck.texture_view,
+                        i,
+                    );
                     let mut encoder =
                         context
                             .device
@@ -687,9 +698,10 @@ impl Channel {
                                 occlusion_query_set: None,
                                 multiview_mask: None,
                             });
-                        self.blit_pipeline.render(&mut render_pass, &bind_group);
+                        self.blit_pipeline
+                            .render_at_slot(&mut render_pass, &bind_group);
                     }
-                    context.queue.submit(std::iter::once(encoder.finish()));
+                    composite_cmds.push(encoder.finish());
                 } else {
                     // Subsequent decks: snapshot + composite shader
                     let mut copy_encoder =
@@ -704,17 +716,19 @@ impl Channel {
                         self.composite_texture.size(),
                     );
 
-                    self.composite_pipeline.set_params(
+                    self.composite_pipeline.write_params_slot(
                         &context.queue,
+                        i,
                         fade_opacity,
                         info.blend_mode.to_index(),
                         [1.0, 1.0],
                         [0.0, 0.0],
                     );
-                    let bind_group = self.composite_pipeline.create_bind_group(
+                    let bind_group = self.composite_pipeline.create_ring_bind_group(
                         &context.device,
                         &slot.deck.texture_view,
                         &self.effect_ping_view,
+                        i,
                     );
                     let mut encoder =
                         context
@@ -741,22 +755,29 @@ impl Channel {
                                 multiview_mask: None,
                             });
                         self.composite_pipeline
-                            .render(&mut render_pass, &bind_group);
+                            .render_at_slot(&mut render_pass, &bind_group);
                     }
-                    context
-                        .queue
-                        .submit([copy_encoder.finish(), encoder.finish()]);
+                    composite_cmds.push(copy_encoder.finish());
+                    composite_cmds.push(encoder.finish());
                 }
                 continue;
             }
 
             // Normal compositing
             if i == 0 {
-                // First deck: simple blit with alpha blending (Normal = just copy)
-                self.blit_pipeline.set_opacity(&context.queue, info.opacity);
-                let bind_group = self
-                    .blit_pipeline
-                    .create_bind_group(&context.device, &slot.deck.texture_view);
+                // First deck: simple blit with per-draw params
+                self.blit_pipeline.write_params_slot(
+                    &context.queue,
+                    i,
+                    info.opacity,
+                    [1.0, 1.0],
+                    [0.0, 0.0],
+                );
+                let bind_group = self.blit_pipeline.create_ring_bind_group(
+                    &context.device,
+                    &slot.deck.texture_view,
+                    i,
+                );
                 let mut encoder =
                     context
                         .device
@@ -780,9 +801,10 @@ impl Channel {
                         occlusion_query_set: None,
                         multiview_mask: None,
                     });
-                    self.blit_pipeline.render(&mut render_pass, &bind_group);
+                    self.blit_pipeline
+                        .render_at_slot(&mut render_pass, &bind_group);
                 }
-                context.queue.submit(std::iter::once(encoder.finish()));
+                composite_cmds.push(encoder.finish());
             } else {
                 // Subsequent decks: snapshot composite → ping, blend src + ping → composite
                 let mut copy_encoder =
@@ -797,17 +819,19 @@ impl Channel {
                     self.composite_texture.size(),
                 );
 
-                self.composite_pipeline.set_params(
+                self.composite_pipeline.write_params_slot(
                     &context.queue,
+                    i,
                     info.opacity,
                     info.blend_mode.to_index(),
                     [1.0, 1.0],
                     [0.0, 0.0],
                 );
-                let bind_group = self.composite_pipeline.create_bind_group(
+                let bind_group = self.composite_pipeline.create_ring_bind_group(
                     &context.device,
                     &slot.deck.texture_view,
                     &self.effect_ping_view,
+                    i,
                 );
                 let mut encoder =
                     context
@@ -833,12 +857,16 @@ impl Channel {
                         multiview_mask: None,
                     });
                     self.composite_pipeline
-                        .render(&mut render_pass, &bind_group);
+                        .render_at_slot(&mut render_pass, &bind_group);
                 }
-                context
-                    .queue
-                    .submit([copy_encoder.finish(), encoder.finish()]);
+                composite_cmds.push(copy_encoder.finish());
+                composite_cmds.push(encoder.finish());
             }
+        }
+
+        // Batch submit all channel composite commands at once
+        if !composite_cmds.is_empty() {
+            context.queue.submit(composite_cmds);
         }
 
         // If no decks, clear the composite texture to transparent

--- a/src/internal/mixer/render.rs
+++ b/src/internal/mixer/render.rs
@@ -231,17 +231,26 @@ impl Mixer {
 
         // Batch channel compositing into command buffers for deferred submission.
         let mut is_first = true;
+        let mut slot: usize = 0;
         for (_i, (channel, &opacity)) in self.channels.iter().zip(opacities.iter()).enumerate() {
             if opacity <= 0.0 {
                 continue;
             }
 
             if is_first {
-                // First visible channel: simple blit copy
-                self.blit_pipeline.set_opacity(&context.queue, opacity);
-                let bind_group = self
-                    .blit_pipeline
-                    .create_bind_group(&context.device, &channel.composite_view);
+                // First visible channel: per-draw params blit
+                self.blit_pipeline.write_params_slot(
+                    &context.queue,
+                    slot,
+                    opacity,
+                    [1.0, 1.0],
+                    [0.0, 0.0],
+                );
+                let bind_group = self.blit_pipeline.create_ring_bind_group(
+                    &context.device,
+                    &channel.composite_view,
+                    slot,
+                );
                 let mut encoder =
                     context
                         .device
@@ -265,12 +274,13 @@ impl Mixer {
                         occlusion_query_set: None,
                         multiview_mask: None,
                     });
-                    self.blit_pipeline.render(&mut render_pass, &bind_group);
+                    self.blit_pipeline
+                        .render_at_slot(&mut render_pass, &bind_group);
                 }
                 cmd_buffers.push(encoder.finish());
                 is_first = false;
             } else {
-                // Subsequent channels: snapshot + composite shader
+                // Subsequent channels: snapshot + per-draw params composite
                 let mut copy_encoder =
                     context
                         .device
@@ -284,17 +294,19 @@ impl Mixer {
                 );
 
                 let blend_mode = channel.blend_mode;
-                self.composite_pipeline.set_params(
+                self.composite_pipeline.write_params_slot(
                     &context.queue,
+                    slot,
                     opacity,
                     blend_mode.to_index(),
                     [1.0, 1.0],
                     [0.0, 0.0],
                 );
-                let bind_group = self.composite_pipeline.create_bind_group(
+                let bind_group = self.composite_pipeline.create_ring_bind_group(
                     &context.device,
                     &channel.composite_view,
                     &self.effect_ping_view,
+                    slot,
                 );
                 let mut encoder =
                     context
@@ -320,11 +332,12 @@ impl Mixer {
                         multiview_mask: None,
                     });
                     self.composite_pipeline
-                        .render(&mut render_pass, &bind_group);
+                        .render_at_slot(&mut render_pass, &bind_group);
                 }
                 cmd_buffers.push(copy_encoder.finish());
                 cmd_buffers.push(encoder.finish());
             }
+            slot += 1;
         }
 
         Ok(cmd_buffers)
@@ -360,6 +373,7 @@ impl Mixer {
 
         let mut cmd_buffers: Vec<wgpu::CommandBuffer> = Vec::new();
         let mut is_first = true;
+        let mut slot: usize = 0;
         for &ch_idx in indices {
             if ch_idx >= self.channels.len() {
                 continue;
@@ -371,11 +385,19 @@ impl Mixer {
             }
 
             if is_first {
-                // First visible channel: simple blit copy
-                self.blit_pipeline.set_opacity(&context.queue, opacity);
-                let bind_group = self
-                    .blit_pipeline
-                    .create_bind_group(&context.device, &channel.composite_view);
+                // First visible channel: per-draw params blit
+                self.blit_pipeline.write_params_slot(
+                    &context.queue,
+                    slot,
+                    opacity,
+                    [1.0, 1.0],
+                    [0.0, 0.0],
+                );
+                let bind_group = self.blit_pipeline.create_ring_bind_group(
+                    &context.device,
+                    &channel.composite_view,
+                    slot,
+                );
                 let mut encoder =
                     context
                         .device
@@ -399,12 +421,13 @@ impl Mixer {
                         occlusion_query_set: None,
                         multiview_mask: None,
                     });
-                    self.blit_pipeline.render(&mut render_pass, &bind_group);
+                    self.blit_pipeline
+                        .render_at_slot(&mut render_pass, &bind_group);
                 }
                 cmd_buffers.push(encoder.finish());
                 is_first = false;
             } else {
-                // Subsequent channels: snapshot sub-mix → effect_ping, composite shader
+                // Subsequent channels: snapshot sub-mix → effect_ping, per-draw params composite
                 let mut copy_encoder =
                     context
                         .device
@@ -418,17 +441,19 @@ impl Mixer {
                 );
 
                 let blend_mode = channel.blend_mode;
-                self.composite_pipeline.set_params(
+                self.composite_pipeline.write_params_slot(
                     &context.queue,
+                    slot,
                     opacity,
                     blend_mode.to_index(),
                     [1.0, 1.0],
                     [0.0, 0.0],
                 );
-                let bind_group = self.composite_pipeline.create_bind_group(
+                let bind_group = self.composite_pipeline.create_ring_bind_group(
                     &context.device,
                     &channel.composite_view,
                     &self.effect_ping_view,
+                    slot,
                 );
                 let mut encoder =
                     context
@@ -454,11 +479,12 @@ impl Mixer {
                         multiview_mask: None,
                     });
                     self.composite_pipeline
-                        .render(&mut render_pass, &bind_group);
+                        .render_at_slot(&mut render_pass, &bind_group);
                 }
                 cmd_buffers.push(copy_encoder.finish());
                 cmd_buffers.push(encoder.finish());
             }
+            slot += 1;
         }
 
         if is_first {

--- a/src/internal/renderer/blit.rs
+++ b/src/internal/renderer/blit.rs
@@ -1,7 +1,12 @@
 use super::edge_blend::SurfaceOverlapZones;
 /// Simple blit pipeline for copying textures to the screen
 use anyhow::Result;
+use std::num::NonZeroU64;
 use wgpu::util::DeviceExt;
+
+/// Maximum number of per-draw parameter slots in the ring buffer.
+/// Supports batching up to 16 composites in a single queue.submit().
+const MAX_DRAW_SLOTS: u64 = 16;
 
 /// Uniform buffer for blit parameters - 32 bytes (8 x f32)
 #[repr(C)]
@@ -21,6 +26,10 @@ pub struct BlitPipeline {
     bind_group_layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
     params_buffer: wgpu::Buffer,
+    /// Pre-allocated ring buffer for per-draw params (avoids per-frame allocation).
+    ring_buffer: wgpu::Buffer,
+    /// Byte stride between slots (aligned to device minimum).
+    ring_stride: u64,
 }
 
 impl BlitPipeline {
@@ -64,7 +73,7 @@ impl BlitPipeline {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: None,
+                        min_binding_size: NonZeroU64::new(std::mem::size_of::<BlitParams>() as u64),
                     },
                     count: None,
                 },
@@ -153,20 +162,34 @@ impl BlitPipeline {
             ..Default::default()
         });
 
+        // Pre-allocate ring buffer for batched per-draw params.
+        let align = device.limits().min_uniform_buffer_offset_alignment as u64;
+        let param_size = std::mem::size_of::<BlitParams>() as u64;
+        let ring_stride = ((param_size + align - 1) / align) * align;
+        let ring_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Blit Params Ring Buffer"),
+            size: MAX_DRAW_SLOTS * ring_stride,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
         Ok(Self {
             pipeline,
             bind_group_layout,
             sampler,
             params_buffer,
+            ring_buffer,
+            ring_stride,
         })
     }
 
-    /// Create a bind group for a texture view
+    /// Create a bind group for a texture view using the static params_buffer.
     pub fn create_bind_group(
         &self,
         device: &wgpu::Device,
         texture_view: &wgpu::TextureView,
     ) -> wgpu::BindGroup {
+        let param_size = std::mem::size_of::<BlitParams>() as u64;
         device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Blit Bind Group"),
             layout: &self.bind_group_layout,
@@ -181,7 +204,11 @@ impl BlitPipeline {
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
-                    resource: self.params_buffer.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.params_buffer,
+                        offset: 0,
+                        size: Some(NonZeroU64::new(param_size).unwrap()),
+                    }),
                 },
             ],
         })
@@ -238,7 +265,7 @@ impl BlitPipeline {
         );
     }
 
-    /// Render a texture to a render pass
+    /// Render a texture to a render pass.
     pub fn render<'a>(
         &'a self,
         render_pass: &mut wgpu::RenderPass<'a>,
@@ -261,30 +288,41 @@ impl BlitPipeline {
         self.render(render_pass, bind_group);
     }
 
-    /// Create a bind group with its own params buffer baked in.
-    /// Use this when you need multiple surfaces with different UV transforms in one render pass.
-    pub fn create_bind_group_with_params(
+    /// Write blit params into a slot of the pre-allocated ring buffer.
+    /// Call once per draw before `create_bind_group_for_slot`.
+    pub fn write_params_slot(
         &self,
-        device: &wgpu::Device,
-        texture_view: &wgpu::TextureView,
+        queue: &wgpu::Queue,
+        slot: usize,
         opacity: f32,
         uv_scale: [f32; 2],
         uv_offset: [f32; 2],
-    ) -> wgpu::BindGroup {
-        let params_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Blit Params Buffer (per-surface)"),
-            contents: bytemuck::cast_slice(&[BlitParams {
+    ) {
+        queue.write_buffer(
+            &self.ring_buffer,
+            slot as u64 * self.ring_stride,
+            bytemuck::cast_slice(&[BlitParams {
                 opacity,
                 rotation: 0,
                 uv_scale,
                 uv_offset,
                 _pad2: [0.0, 0.0],
             }]),
-            usage: wgpu::BufferUsages::UNIFORM,
-        });
+        );
+    }
 
+    /// Create a bind group for a specific ring buffer slot.
+    /// The slot offset is baked into the bind group — no dynamic offset overhead.
+    pub fn create_ring_bind_group(
+        &self,
+        device: &wgpu::Device,
+        texture_view: &wgpu::TextureView,
+        slot: usize,
+    ) -> wgpu::BindGroup {
+        let param_size = std::mem::size_of::<BlitParams>() as u64;
+        let offset = slot as u64 * self.ring_stride;
         device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("Blit Bind Group (per-surface)"),
+            label: Some("Blit Bind Group (ring)"),
             layout: &self.bind_group_layout,
             entries: &[
                 wgpu::BindGroupEntry {
@@ -297,10 +335,26 @@ impl BlitPipeline {
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
-                    resource: params_buffer.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.ring_buffer,
+                        offset,
+                        size: Some(NonZeroU64::new(param_size).unwrap()),
+                    }),
                 },
             ],
         })
+    }
+
+    /// Render using a ring buffer slot's bind group.
+    /// The bind group must have been created with `create_ring_bind_group`.
+    pub fn render_at_slot<'a>(
+        &'a self,
+        render_pass: &mut wgpu::RenderPass<'a>,
+        bind_group: &'a wgpu::BindGroup,
+    ) {
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, bind_group, &[]);
+        render_pass.draw(0..3, 0..1);
     }
 }
 
@@ -326,6 +380,10 @@ pub struct CompositeBlitPipeline {
     bind_group_layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
     params_buffer: wgpu::Buffer,
+    /// Pre-allocated ring buffer for per-draw params (avoids per-frame allocation).
+    ring_buffer: wgpu::Buffer,
+    /// Byte stride between slots (aligned to device minimum).
+    ring_stride: u64,
 }
 
 impl CompositeBlitPipeline {
@@ -370,7 +428,9 @@ impl CompositeBlitPipeline {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: None,
+                        min_binding_size: NonZeroU64::new(
+                            std::mem::size_of::<CompositeParams>() as u64
+                        ),
                     },
                     count: None,
                 },
@@ -454,11 +514,24 @@ impl CompositeBlitPipeline {
             ..Default::default()
         });
 
+        // Pre-allocate ring buffer for batched per-draw params.
+        let align = device.limits().min_uniform_buffer_offset_alignment as u64;
+        let param_size = std::mem::size_of::<CompositeParams>() as u64;
+        let ring_stride = ((param_size + align - 1) / align) * align;
+        let ring_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Composite Params Ring Buffer"),
+            size: MAX_DRAW_SLOTS * ring_stride,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
         Ok(Self {
             pipeline,
             bind_group_layout,
             sampler,
             params_buffer,
+            ring_buffer,
+            ring_stride,
         })
     }
 
@@ -491,6 +564,7 @@ impl CompositeBlitPipeline {
         source_view: &wgpu::TextureView,
         dest_view: &wgpu::TextureView,
     ) -> wgpu::BindGroup {
+        let param_size = std::mem::size_of::<CompositeParams>() as u64;
         device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Composite Bind Group"),
             layout: &self.bind_group_layout,
@@ -509,7 +583,11 @@ impl CompositeBlitPipeline {
                 },
                 wgpu::BindGroupEntry {
                     binding: 3,
-                    resource: self.params_buffer.as_entire_binding(),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.params_buffer,
+                        offset: 0,
+                        size: Some(NonZeroU64::new(param_size).unwrap()),
+                    }),
                 },
             ],
         })
@@ -517,6 +595,81 @@ impl CompositeBlitPipeline {
 
     /// Render: draw fullscreen quad with composite shader.
     pub fn render<'a>(
+        &'a self,
+        render_pass: &mut wgpu::RenderPass<'a>,
+        bind_group: &'a wgpu::BindGroup,
+    ) {
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, bind_group, &[]);
+        render_pass.draw(0..3, 0..1);
+    }
+
+    /// Write composite params into a slot of the pre-allocated ring buffer.
+    /// Call once per draw before `create_bind_group_for_slot`.
+    pub fn write_params_slot(
+        &self,
+        queue: &wgpu::Queue,
+        slot: usize,
+        opacity: f32,
+        blend_mode: u32,
+        uv_scale: [f32; 2],
+        uv_offset: [f32; 2],
+    ) {
+        queue.write_buffer(
+            &self.ring_buffer,
+            slot as u64 * self.ring_stride,
+            bytemuck::cast_slice(&[CompositeParams {
+                opacity,
+                blend_mode,
+                uv_scale,
+                uv_offset,
+                _pad: [0.0, 0.0],
+            }]),
+        );
+    }
+
+    /// Create a bind group for a specific ring buffer slot.
+    /// The slot offset is baked into the bind group — no dynamic offset overhead.
+    pub fn create_ring_bind_group(
+        &self,
+        device: &wgpu::Device,
+        source_view: &wgpu::TextureView,
+        dest_view: &wgpu::TextureView,
+        slot: usize,
+    ) -> wgpu::BindGroup {
+        let param_size = std::mem::size_of::<CompositeParams>() as u64;
+        let offset = slot as u64 * self.ring_stride;
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Composite Bind Group (ring)"),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(source_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(dest_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.ring_buffer,
+                        offset,
+                        size: Some(NonZeroU64::new(param_size).unwrap()),
+                    }),
+                },
+            ],
+        })
+    }
+
+    /// Render using a ring buffer slot's bind group.
+    /// The bind group must have been created with `create_ring_bind_group`.
+    pub fn render_at_slot<'a>(
         &'a self,
         render_pass: &mut wgpu::RenderPass<'a>,
         bind_group: &'a wgpu::BindGroup,

--- a/src/internal/renderer/dome.rs
+++ b/src/internal/renderer/dome.rs
@@ -351,13 +351,11 @@ impl DomemasterRenderer {
         ];
 
         for (i, (opacity, uv_scale, uv_offset)) in face_uv_configs.iter().enumerate() {
-            let bind_group = self.face_blit.create_bind_group_with_params(
-                device,
-                source_view,
-                *opacity,
-                *uv_scale,
-                *uv_offset,
-            );
+            self.face_blit
+                .write_params_slot(queue, i, *opacity, *uv_scale, *uv_offset);
+            let bind_group = self
+                .face_blit
+                .create_ring_bind_group(device, source_view, i);
             let mut rp = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Dome Face Render"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -375,7 +373,7 @@ impl DomemasterRenderer {
                 multiview_mask: None,
             });
             if *opacity > 0.0 {
-                self.face_blit.render(&mut rp, &bind_group);
+                self.face_blit.render_at_slot(&mut rp, &bind_group);
             }
         }
 


### PR DESCRIPTION
replace per-frame `create_buffer_init` allocations with a persistent ring buffer for per-draw uniform params. each compositing draw writes its params to a pre-allocated slot and bakes the offset into the bind group, yeeting both the allocation and the staging-buffer deallocation pressure that was bottlenecking older hardware. 

## Same Session A/B Results
| Benchmark | Before (main) | After | Change |
|-----------|--------------|-------|--------|
| solid/1 | 1.76 ms | 1.63 ms | **-7.1%** |
| solid/2 | 2.05 ms | 1.62 ms | **-22.4%** |
| solid/4 | 2.32 ms | 2.43 ms | +2.4% (noise) |
| solid/8 | 3.69 ms | 3.28 ms | **-10.8%** |
| shader/1 | 1.86 ms | 1.68 ms | **-8.8%** |
| shader/2 | 2.13 ms | 1.79 ms | **-15.2%** |
| shader/4 | 2.76 ms | 2.44 ms | **-10.7%** |
| shader/8 | 4.21 ms | 3.55 ms | **-16.1%** |
| mixer crossfade | 2.22 ms | 1.78 ms | **-17.9%** |