### PR TITLE
feat: syhpon I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6433,7 +6433,9 @@ checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
+ "dispatch2",
  "objc2 0.6.4",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -11451,6 +11453,9 @@ dependencies = [
  "ndarray",
  "nokhwa",
  "notify",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
  "ort",
  "pollster",
  "rfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,7 +4354,9 @@ checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
+ "dispatch2",
  "objc2 0.6.4",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -6699,6 +6701,9 @@ dependencies = [
  "ndarray",
  "nokhwa",
  "notify",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
  "ort",
  "pollster",
  "rfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11418,7 +11418,7 @@ dependencies = [
 
 [[package]]
 name = "varda"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,14 @@ arc-swap = "1.9.1"
 ort = { version = "2.0.0-rc.12", optional = true }
 ndarray = { version = "0.17.2", optional = true }
 
+# Syphon client FFI (macOS only). The syphon module is compiled unconditionally
+# on macOS; Syphon.framework itself is dlopen'd at runtime (via libloading), so
+# these crates are the only build-time additions.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2            = "0.6"
+objc2-foundation = "0.3"
+objc2-metal      = "0.3"
+
 [features]
 default = ["face-detection"]
 # ML-backed analyzers (ONNX Runtime + ndarray). Disabled for the x86_64 macOS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "varda"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Varda Contributors"]
 description = "Linux and MacOS native VJ software with ISF/GLSL shader support"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,14 @@ servo = { version = "0.1.0", optional = true }
 url = { version = "2.5", optional = true }
 euclid = { version = "0.22", optional = true }
 
+# Syphon client FFI (macOS only). The syphon module is compiled unconditionally
+# on macOS; Syphon.framework itself is dlopen'd at runtime (via libloading), so
+# these crates are the only build-time additions.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2            = "0.6"
+objc2-foundation = "0.3"
+objc2-metal      = "0.3"
+
 [features]
 default = ["face-detection", "html"]
 # ML-backed analyzers (ONNX Runtime + ndarray). Disabled for the x86_64 macOS

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open-source visual performance tool with broadcast-style routing for VJs and ins
 Varda applies broadcast video workflows to live visuals. Sources (video, cameras, generative shaders, streams, images) flow through a routing graph of decks, channels, and surfaces to reach outputs (projectors, streams, recordings). Instead of a clip-launch grid, you control what's live by adjusting opacity, blend modes, crossfaders, mute/solo, and effect chains. 
 
 - **Routing matrix**: Sources > Decks > Channels > Mixer > Surfaces > Outputs. Any source to any output, split, branch, or sub-mix at every junction
-- **Sources**: video (HAP GPU-native + ffmpeg), cameras, ISF shaders (generators/filters), NDI, SRT, HLS, DASH, RTMP/RTMPS, Syphon (macOS receive), images
+- **Sources**: video (HAP GPU-native + ffmpeg), cameras, ISF shaders (generators/filters), NDI, SRT, HLS, DASH, RTMP/RTMPS, Syphon (macOS receive), images, and html/css/js sources (Servo)
 - **Mixing**: N-channel compositing, A/B crossfader, per-deck opacity, 15 blend modes, linear-light HDR pipeline
 - **Color**: 9 tonemap presets (ACES, AgX, Reinhard, Hable, etc.), 3D LUT support (.cube/.3dl) for color grading
 - **Transitions**: ISF shader transitions between channels, deck auto-transitions (timer/clip-end triggers), multi-channel transition sequencer with beat-synced or timed triggers (seconds, minutes, hours). Allowing for quick automated live transitions or long running automated installations.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open-source visual performance tool with broadcast-style routing for VJs and ins
 Varda applies broadcast video workflows to live visuals. Sources (video, cameras, generative shaders, streams, images) flow through a routing graph of decks, channels, and surfaces to reach outputs (projectors, streams, recordings). Instead of a clip-launch grid, you control what's live by adjusting opacity, blend modes, crossfaders, mute/solo, and effect chains. 
 
 - **Routing matrix**: Sources > Decks > Channels > Mixer > Surfaces > Outputs. Any source to any output, split, branch, or sub-mix at every junction
-- **Sources**: video (HAP GPU-native + ffmpeg), cameras, ISF shaders (generators/filters), NDI, SRT, HLS, DASH, RTMP/RTMPS, images
+- **Sources**: video (HAP GPU-native + ffmpeg), cameras, ISF shaders (generators/filters), NDI, SRT, HLS, DASH, RTMP/RTMPS, Syphon (macOS receive), images
 - **Mixing**: N-channel compositing, A/B crossfader, per-deck opacity, 15 blend modes, linear-light HDR pipeline
 - **Color**: 9 tonemap presets (ACES, AgX, Reinhard, Hable, etc.), 3D LUT support (.cube/.3dl) for color grading
 - **Transitions**: ISF shader transitions between channels, deck auto-transitions (timer/clip-end triggers), multi-channel transition sequencer with beat-synced or timed triggers (seconds, minutes, hours). Allowing for quick automated live transitions or long running automated installations.

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -51,7 +51,7 @@ Renders assigned surfaces onto a display target — a monitor/projector window, 
 | DASH | MPEG-DASH input |
 | RTMP | RTMP/RTMPS stream receive |
 | Compute Shader | GLSL compute shader (`.comp`) — particle systems, simulations, GPU-native generators |
-| Syphon | macOS inter-app texture sharing (runtime bridge pending) |
+| Syphon | macOS inter-app texture sharing (receive from other apps) |
 | Solid Color | Flat RGBA color |
 
 ---

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -51,7 +51,7 @@ Renders assigned surfaces onto a display target — a monitor/projector window, 
 | DASH | MPEG-DASH input |
 | RTMP | RTMP/RTMPS stream receive |
 | Compute Shader | GLSL compute shader (`.comp`) — particle systems, simulations, GPU-native generators |
-| Syphon | macOS inter-app texture sharing (runtime bridge pending) |
+| Syphon | macOS inter-app texture sharing (receive from other apps) |
 | HTML | Web page (HTML/CSS/JS) rendered by the embedded Servo browser engine |
 | Solid Color | Flat RGBA color |
 

--- a/docs/09-streaming-and-io.md
+++ b/docs/09-streaming-and-io.md
@@ -214,7 +214,6 @@ HTML is rasterized on the **CPU** (Servo's software renderer) and uploaded to a 
 
 ## Syphon (macOS)
 
-<<<<<<< HEAD
 Syphon enables inter-application GPU texture sharing on macOS. Varda works both ways: as a Syphon **client** (receiving other apps' frames as live sources) and as a Syphon **server** (publishing a Varda output for other apps to consume).
 
 **Receive (client):**
@@ -232,14 +231,6 @@ Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded i
 4. Start the output — other Syphon apps then see it in their source list
 
 Publishing is **zero-copy on the GPU**: the rendered output is converted (RGBA→BGRA) by a GPU pass and shared directly via Metal — no CPU readback.
-=======
-Syphon enables inter-application GPU texture sharing on macOS. Varda acts as a Syphon **client**: it discovers servers published by other apps (Resolume, VDMX, MadMapper, etc.) and receives their frames as live sources.
-
-1. Open the Library and look under **Syphon Sources** for discovered servers
-2. **Drag** a server into a channel to create a live deck
-
-Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded into Varda's wgpu texture path via CPU readback — a cheap same-memory copy on Apple-silicon unified memory. A zero-copy path (wrapping the IOSurface texture directly as a `wgpu::Texture`) is a possible follow-on.
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
 
 ### Installing Syphon.framework
 
@@ -264,11 +255,7 @@ This is the standard, verified location — it is also where other Syphon apps o
 
 Pass `--no-syphon` to disable Syphon explicitly even when the framework is installed.
 
-<<<<<<< HEAD
 > **Note:** Varda is both a Syphon client (receive) and a Syphon server (publish a `SyphonServer` output).
-=======
-> **Note:** Varda is a Syphon client (receive only); it does not publish its output as a Syphon server.
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
 
 ---
 

--- a/docs/09-streaming-and-io.md
+++ b/docs/09-streaming-and-io.md
@@ -214,9 +214,16 @@ HTML is rasterized on the **CPU** (Servo's software renderer) and uploaded to a 
 
 ## Syphon (macOS)
 
-Syphon enables inter-application GPU texture sharing on macOS. Varda includes framework detection and server discovery.
+Syphon enables inter-application GPU texture sharing on macOS. Varda acts as a Syphon **client**: it discovers servers published by other apps (Resolume, VDMX, MadMapper, etc.) and receives their frames as live sources.
 
-> **Note:** The runtime IOSurface↔wgpu Metal bridge is pending implementation. Syphon sources appear in the library but full texture sharing is not yet functional.
+1. Open the Library and look under **Syphon Sources** for discovered servers
+2. **Drag** a server into a channel to create a live deck
+
+Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded into Varda's wgpu texture path via CPU readback — a cheap same-memory copy on Apple-silicon unified memory. A zero-copy path (wrapping the IOSurface texture directly as a `wgpu::Texture`) is a possible follow-on.
+
+`Syphon.framework` is loaded at runtime, so Macs without Syphon installed still run normally — Syphon features simply stay disabled. Pass `--no-syphon` to disable it explicitly.
+
+> **Note:** Varda is a Syphon client (receive only); it does not publish its output as a Syphon server.
 
 ---
 

--- a/docs/09-streaming-and-io.md
+++ b/docs/09-streaming-and-io.md
@@ -214,12 +214,23 @@ HTML is rasterized on the **CPU** (Servo's software renderer) and uploaded to a 
 
 ## Syphon (macOS)
 
-Syphon enables inter-application GPU texture sharing on macOS. Varda acts as a Syphon **client**: it discovers servers published by other apps (Resolume, VDMX, MadMapper, etc.) and receives their frames as live sources.
+Syphon enables inter-application GPU texture sharing on macOS. Varda works both ways: as a Syphon **client** (receiving other apps' frames as live sources) and as a Syphon **server** (publishing a Varda output for other apps to consume).
+
+**Receive (client):**
 
 1. Open the Library and look under **Syphon Sources** for discovered servers
 2. **Drag** a server into a channel to create a live deck
 
-Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded into Varda's wgpu texture path via CPU readback — a cheap same-memory copy on Apple-silicon unified memory. A zero-copy path (wrapping the IOSurface texture directly as a `wgpu::Texture`) is a possible follow-on.
+Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded into Varda's wgpu texture path via CPU readback — a cheap same-memory copy on Apple-silicon unified memory. A zero-copy receive path (wrapping the IOSurface texture directly as a `wgpu::Texture`) is a possible follow-on.
+
+**Publish (server):**
+
+1. In the output panel, click **+ Stream**
+2. Select **Syphon** from the protocol dropdown
+3. Enter a server name (e.g., "Varda Main")
+4. Start the output — other Syphon apps then see it in their source list
+
+Publishing is **zero-copy on the GPU**: the rendered output is converted (RGBA→BGRA) by a GPU pass and shared directly via Metal — no CPU readback.
 
 ### Installing Syphon.framework
 
@@ -244,7 +255,7 @@ This is the standard, verified location — it is also where other Syphon apps o
 
 Pass `--no-syphon` to disable Syphon explicitly even when the framework is installed.
 
-> **Note:** Varda is a Syphon client (receive only); it does not publish its output as a Syphon server.
+> **Note:** Varda is both a Syphon client (receive) and a Syphon server (publish a `SyphonServer` output).
 
 ---
 

--- a/docs/09-streaming-and-io.md
+++ b/docs/09-streaming-and-io.md
@@ -181,9 +181,16 @@ Stream sources are grouped under a single **Stream Sources** header in the Libra
 
 ## Syphon (macOS)
 
-Syphon enables inter-application GPU texture sharing on macOS. Varda includes framework detection and server discovery.
+Syphon enables inter-application GPU texture sharing on macOS. Varda acts as a Syphon **client**: it discovers servers published by other apps (Resolume, VDMX, MadMapper, etc.) and receives their frames as live sources.
 
-> **Note:** The runtime IOSurface↔wgpu Metal bridge is pending implementation. Syphon sources appear in the library but full texture sharing is not yet functional.
+1. Open the Library and look under **Syphon Sources** for discovered servers
+2. **Drag** a server into a channel to create a live deck
+
+Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded into Varda's wgpu texture path via CPU readback — a cheap same-memory copy on Apple-silicon unified memory. A zero-copy path (wrapping the IOSurface texture directly as a `wgpu::Texture`) is a possible follow-on.
+
+`Syphon.framework` is loaded at runtime, so Macs without Syphon installed still run normally — Syphon features simply stay disabled. Pass `--no-syphon` to disable it explicitly.
+
+> **Note:** Varda is a Syphon client (receive only); it does not publish its output as a Syphon server.
 
 ---
 

--- a/docs/09-streaming-and-io.md
+++ b/docs/09-streaming-and-io.md
@@ -188,7 +188,28 @@ Syphon enables inter-application GPU texture sharing on macOS. Varda acts as a S
 
 Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded into Varda's wgpu texture path via CPU readback — a cheap same-memory copy on Apple-silicon unified memory. A zero-copy path (wrapping the IOSurface texture directly as a `wgpu::Texture`) is a possible follow-on.
 
-`Syphon.framework` is loaded at runtime, so Macs without Syphon installed still run normally — Syphon features simply stay disabled. Pass `--no-syphon` to disable it explicitly.
+### Installing Syphon.framework
+
+Syphon support needs **nothing special at build time** — `Syphon.framework` is *not* linked, it is loaded at runtime via `dlopen`. A normal macOS build (`cargo build` / `cargo run`) works whether or not Syphon is installed; if it is missing, Syphon features simply stay disabled and the rest of Varda runs normally.
+
+To *use* Syphon, install the framework system-wide at:
+
+```
+/Library/Frameworks/Syphon.framework
+```
+
+This is the standard, verified location — it is also where other Syphon apps on the system expect to find the framework, so a single system-wide install serves all of them. To install it:
+
+1. Get `Syphon.framework` — download it from the [official Syphon-Framework releases](https://github.com/Syphon/Syphon-Framework/releases), or copy it out of any Syphon-enabled app bundle (e.g. Simple Syphon, Resolume, VDMX, MadMapper).
+2. Copy the `Syphon.framework` folder into `/Library/Frameworks/` (requires admin):
+   ```sh
+   sudo cp -R /path/to/Syphon.framework /Library/Frameworks/
+   ```
+3. Launch Varda. On startup the log shows `Syphon.framework found` when it loaded successfully, or `Syphon.framework not found — Syphon features disabled` otherwise.
+
+> Varda also checks `~/Library/Frameworks/Syphon.framework` (per-user, no admin) as a fallback. The system-wide `/Library/Frameworks/` path above is the recommended and verified one.
+
+Pass `--no-syphon` to disable Syphon explicitly even when the framework is installed.
 
 > **Note:** Varda is a Syphon client (receive only); it does not publish its output as a Syphon server.
 

--- a/docs/09-streaming-and-io.md
+++ b/docs/09-streaming-and-io.md
@@ -221,7 +221,28 @@ Syphon enables inter-application GPU texture sharing on macOS. Varda acts as a S
 
 Frames are pulled per-frame from the Syphon server's `MTLTexture` and uploaded into Varda's wgpu texture path via CPU readback — a cheap same-memory copy on Apple-silicon unified memory. A zero-copy path (wrapping the IOSurface texture directly as a `wgpu::Texture`) is a possible follow-on.
 
-`Syphon.framework` is loaded at runtime, so Macs without Syphon installed still run normally — Syphon features simply stay disabled. Pass `--no-syphon` to disable it explicitly.
+### Installing Syphon.framework
+
+Syphon support needs **nothing special at build time** — `Syphon.framework` is *not* linked, it is loaded at runtime via `dlopen`. A normal macOS build (`cargo build` / `cargo run`) works whether or not Syphon is installed; if it is missing, Syphon features simply stay disabled and the rest of Varda runs normally.
+
+To *use* Syphon, install the framework system-wide at:
+
+```
+/Library/Frameworks/Syphon.framework
+```
+
+This is the standard, verified location — it is also where other Syphon apps on the system expect to find the framework, so a single system-wide install serves all of them. To install it:
+
+1. Get `Syphon.framework` — download it from the [official Syphon-Framework releases](https://github.com/Syphon/Syphon-Framework/releases), or copy it out of any Syphon-enabled app bundle (e.g. Simple Syphon, Resolume, VDMX, MadMapper).
+2. Copy the `Syphon.framework` folder into `/Library/Frameworks/` (requires admin):
+   ```sh
+   sudo cp -R /path/to/Syphon.framework /Library/Frameworks/
+   ```
+3. Launch Varda. On startup the log shows `Syphon.framework found` when it loaded successfully, or `Syphon.framework not found — Syphon features disabled` otherwise.
+
+> Varda also checks `~/Library/Frameworks/Syphon.framework` (per-user, no admin) as a fallback. The system-wide `/Library/Frameworks/` path above is the recommended and verified one.
+
+Pass `--no-syphon` to disable Syphon explicitly even when the framework is installed.
 
 > **Note:** Varda is a Syphon client (receive only); it does not publish its output as a Syphon server.
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -157,6 +157,14 @@ pub(crate) struct ExternalIO {
     pub ndi_manager: crate::ndi::NdiManager,
     #[cfg(target_os = "macos")]
     pub syphon_manager: crate::syphon::SyphonManager,
+    /// Syphon decks restored from the workspace whose server is not yet
+    /// published. The render thread auto-binds them once the server appears
+    /// (`VardaApp::reconcile_syphon`). See `persistence::PendingSyphonDeck`.
+    #[cfg(target_os = "macos")]
+    pub pending_syphon: Vec<crate::persistence::PendingSyphonDeck>,
+    /// Throttle for periodic Syphon re-discovery on the render thread.
+    #[cfg(target_os = "macos")]
+    pub last_syphon_scan: std::time::Instant,
     pub stream_manager: crate::stream::StreamManager,
     pub stream_library: Vec<(String, crate::stream::SrtMode)>,
     pub hls_library: Vec<String>,
@@ -415,6 +423,10 @@ impl VardaApp {
                 } else {
                     crate::syphon::SyphonManager::new()
                 },
+                #[cfg(target_os = "macos")]
+                pending_syphon: Vec::new(),
+                #[cfg(target_os = "macos")]
+                last_syphon_scan: std::time::Instant::now(),
                 stream_manager: crate::stream::StreamManager::new(),
                 stream_library: Vec::new(),
                 hls_library: Vec::new(),
@@ -1690,9 +1702,25 @@ impl VardaApp {
                 CommandResult::Ok
             }
             EngineCommand::RescanSyphon => {
+                // Run discovery inline on the render thread and return the fresh
+                // source list in the same response. This makes an external
+                // probe a single non-racy call: the old fire-and-forget rescan +
+                // separate snapshot GET could read a pre-discover (empty) list and
+                // spuriously "defer Syphon init".
                 #[cfg(target_os = "macos")]
-                self.external_io.syphon_manager.discover();
-                CommandResult::Ok
+                {
+                    self.external_io.syphon_manager.discover();
+                    let names = self.external_io.syphon_manager.discovered_sources();
+                    CommandResult::OkWithData {
+                        data: serde_json::json!(names),
+                    }
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    CommandResult::OkWithData {
+                        data: serde_json::json!([] as [String; 0]),
+                    }
+                }
             }
             EngineCommand::RescanCameras => {
                 self.camera_manager.scan_devices();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -153,6 +153,14 @@ pub(crate) struct ExternalIO {
     pub ndi_manager: crate::ndi::NdiManager,
     #[cfg(target_os = "macos")]
     pub syphon_manager: crate::syphon::SyphonManager,
+    /// Syphon decks restored from the workspace whose server is not yet
+    /// published. The render thread auto-binds them once the server appears
+    /// (`VardaApp::reconcile_syphon`). See `persistence::PendingSyphonDeck`.
+    #[cfg(target_os = "macos")]
+    pub pending_syphon: Vec<crate::persistence::PendingSyphonDeck>,
+    /// Throttle for periodic Syphon re-discovery on the render thread.
+    #[cfg(target_os = "macos")]
+    pub last_syphon_scan: std::time::Instant,
     pub stream_manager: crate::stream::StreamManager,
     pub stream_library: Vec<(String, crate::stream::SrtMode)>,
     pub hls_library: Vec<String>,
@@ -409,6 +417,10 @@ impl VardaApp {
                 } else {
                     crate::syphon::SyphonManager::new()
                 },
+                #[cfg(target_os = "macos")]
+                pending_syphon: Vec::new(),
+                #[cfg(target_os = "macos")]
+                last_syphon_scan: std::time::Instant::now(),
                 stream_manager: crate::stream::StreamManager::new(),
                 stream_library: Vec::new(),
                 hls_library: Vec::new(),
@@ -1675,9 +1687,25 @@ impl VardaApp {
                 CommandResult::Ok
             }
             EngineCommand::RescanSyphon => {
+                // Run discovery inline on the render thread and return the fresh
+                // source list in the same response. This makes an external
+                // probe a single non-racy call: the old fire-and-forget rescan +
+                // separate snapshot GET could read a pre-discover (empty) list and
+                // spuriously "defer Syphon init".
                 #[cfg(target_os = "macos")]
-                self.external_io.syphon_manager.discover();
-                CommandResult::Ok
+                {
+                    self.external_io.syphon_manager.discover();
+                    let names = self.external_io.syphon_manager.discovered_sources();
+                    CommandResult::OkWithData {
+                        data: serde_json::json!(names),
+                    }
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    CommandResult::OkWithData {
+                        data: serde_json::json!([] as [String; 0]),
+                    }
+                }
             }
             EngineCommand::RescanCameras => {
                 self.camera_manager.scan_devices();

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -270,7 +270,9 @@ impl VardaApp {
 
         // Update Syphon client frames
         #[cfg(target_os = "macos")]
-        self.external_io.syphon_manager.update(&self.context.queue);
+        self.external_io
+            .syphon_manager
+            .update(&self.context.device, &self.context.queue);
 
         // Update stream receiver frames
         self.external_io.stream_manager.update(&self.context.queue);
@@ -726,72 +728,99 @@ impl VardaApp {
                 );
             }
 
-            // Enqueue readback copy from the now-rendered texture
-            h.readback.begin_readback(&mut encoder, &h.texture);
+            // Syphon (macOS) publishes GPU-side (zero-copy): skip the CPU
+            // readback entirely and hand the rendered texture to the server.
+            #[cfg(target_os = "macos")]
+            let is_syphon = matches!(
+                &h.target,
+                crate::renderer::context::OutputTarget::SyphonServer { .. }
+            );
+            #[cfg(not(target_os = "macos"))]
+            let is_syphon = false;
+
+            if !is_syphon {
+                // Enqueue readback copy from the now-rendered texture
+                h.readback.begin_readback(&mut encoder, &h.texture);
+            }
             context.queue.submit(std::iter::once(encoder.finish()));
 
+            #[cfg(target_os = "macos")]
+            if let crate::renderer::context::OutputTarget::SyphonServer { ref server_name } =
+                h.target
+            {
+                sinks.syphon_manager.publish_frame_gpu(
+                    &context.device,
+                    &context.queue,
+                    server_name,
+                    &h.texture_view,
+                    h.width,
+                    h.height,
+                );
+            }
+
             // Deliver previous frame's readback data to target
-            if let Some(frame_data) = h.readback.try_read(&context.device) {
-                match h.deliver_frame(
-                    &frame_data,
-                    sinks.ndi_manager,
-                    #[cfg(target_os = "macos")]
-                    sinks.syphon_manager,
-                ) {
-                    crate::renderer::context::DeliveryResult::Failed(msg) => {
-                        log::error!("{}", msg);
-                        h.active = false;
-                    }
-                    crate::renderer::context::DeliveryResult::SrtNeedsRestart => {
-                        // The disconnected client's PCM tap is now stale; drop it,
-                        // then respawn the listener with a fresh audio tap so the
-                        // reconnecting client gets audio again (parity with start).
-                        if let Some(stale) = h.audio_pcm.take() {
-                            sinks
-                                .audio_manager
-                                .unsubscribe_pcm(stale.source_id, stale.token);
+            if !is_syphon {
+                if let Some(frame_data) = h.readback.try_read(&context.device) {
+                    match h.deliver_frame(&frame_data, sinks.ndi_manager) {
+                        crate::renderer::context::DeliveryResult::Failed(msg) => {
+                            log::error!("{}", msg);
+                            h.active = false;
                         }
-                        let (url, codec) = match &h.target {
-                            crate::renderer::context::OutputTarget::SrtStream {
-                                url,
-                                codec,
-                                ..
-                            } => (url.clone(), codec.clone()),
-                            _ => continue,
-                        };
-                        let device = h.target.audio_device().map(str::to_string);
-                        let name = h.name.clone();
-                        let (audio_input, passthrough) = super::state::resolve_output_audio(
-                            sinks.audio_manager,
-                            sinks.notifications,
-                            device.as_deref(),
-                            &name,
-                        );
-                        match crate::renderer::FfmpegSubprocess::spawn_srt(
-                            &url,
-                            &codec,
-                            h.width,
-                            h.height,
-                            30,
-                            audio_input,
-                        ) {
-                            Ok(new_sub) => {
-                                h.subprocess = Some(new_sub);
-                                h.audio_pcm = passthrough.map(Box::new);
-                                log::info!("SRT restarted for '{}'", name);
+                        crate::renderer::context::DeliveryResult::SrtNeedsRestart => {
+                            // The disconnected client's PCM tap is now stale; drop it,
+                            // then respawn the listener with a fresh audio tap so the
+                            // reconnecting client gets audio again (parity with start).
+                            if let Some(stale) = h.audio_pcm.take() {
+                                sinks
+                                    .audio_manager
+                                    .unsubscribe_pcm(stale.source_id, stale.token);
                             }
-                            Err(e) => {
-                                if let Some(pass) = passthrough {
-                                    sinks
-                                        .audio_manager
-                                        .unsubscribe_pcm(pass.source_id, pass.token);
+                            let (url, codec) = match &h.target {
+                                crate::renderer::context::OutputTarget::SrtStream {
+                                    url,
+                                    codec,
+                                    ..
+                                } => (url.clone(), codec.clone()),
+                                _ => continue,
+                            };
+                            let device = h.target.audio_device().map(str::to_string);
+                            let name = h.name.clone();
+                            let (audio_input, passthrough) = super::state::resolve_output_audio(
+                                sinks.audio_manager,
+                                sinks.notifications,
+                                device.as_deref(),
+                                &name,
+                            );
+                            match crate::renderer::FfmpegSubprocess::spawn_srt(
+                                &url,
+                                &codec,
+                                h.width,
+                                h.height,
+                                30,
+                                audio_input,
+                            ) {
+                                Ok(new_sub) => {
+                                    h.subprocess = Some(new_sub);
+                                    h.audio_pcm = passthrough.map(Box::new);
+                                    log::info!("SRT restarted for '{}'", name);
                                 }
-                                log::error!("Failed to restart SRT listener for '{}': {}", name, e);
-                                h.active = false;
+                                Err(e) => {
+                                    if let Some(pass) = passthrough {
+                                        sinks
+                                            .audio_manager
+                                            .unsubscribe_pcm(pass.source_id, pass.token);
+                                    }
+                                    log::error!(
+                                        "Failed to restart SRT listener for '{}': {}",
+                                        name,
+                                        e
+                                    );
+                                    h.active = false;
+                                }
                             }
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -262,6 +262,12 @@ impl VardaApp {
             .ndi_manager
             .update(&self.context.device, &self.context.queue);
 
+        // Periodic Syphon re-discovery + late-bind of deferred decks (~1×/sec).
+        // Removes the start/stop-ordering dependency: a producer that joins or
+        // restarts after Varda is picked up automatically.
+        #[cfg(target_os = "macos")]
+        self.reconcile_syphon();
+
         // Update Syphon client frames
         #[cfg(target_os = "macos")]
         self.external_io.syphon_manager.update(&self.context.queue);

--- a/src/app/state/io.rs
+++ b/src/app/state/io.rs
@@ -56,6 +56,25 @@ impl VardaApp {
     ) -> CommandResult {
         #[cfg(target_os = "macos")]
         {
+            // Idempotency: if this channel already carries a Syphon deck for this
+            // server, do nothing. An external controller may re-subscribe on every
+            // reconnect, and our own reconcile may also bind it — both must
+            // converge to a single deck, not stack duplicates.
+            let display_name = format!("🔗 {}", server_name);
+            if let Some(ch) = self.mixer.channels().get(channel_idx) {
+                if ch
+                    .decks
+                    .iter()
+                    .any(|s| s.deck.source_name() == display_name)
+                {
+                    log::debug!(
+                        "Syphon deck '{}' already present on channel {}; add is a no-op",
+                        server_name,
+                        channel_idx
+                    );
+                    return CommandResult::Ok;
+                }
+            }
             match self
                 .external_io
                 .syphon_manager
@@ -363,5 +382,98 @@ impl VardaApp {
     pub fn cmd_remove_rtmp_library_entry(&mut self, url: String) -> CommandResult {
         self.external_io.rtmp_library.retain(|(u, _)| u != &url);
         CommandResult::Ok
+    }
+
+    /// Render-thread Syphon maintenance, called ~1×/sec (see `render_mixer_frame`).
+    ///
+    /// Two jobs, both removing the start/stop-ordering fragility that used to
+    /// require coordinated launch and manual re-probes:
+    ///   1. **Auto-rediscover** — re-scan `SyphonServerDirectory` so a producer
+    ///      that starts, restarts, or republishes *after* Varda is noticed
+    ///      without an external rescan poke. Keeps the snapshot/library list
+    ///      fresh for the UI and any external controller's GET fallback.
+    ///   2. **Late-bind pending decks** — any Syphon deck deferred at restore
+    ///      time (`persistence::PendingSyphonDeck`) is attached the moment its
+    ///      named server appears. No black_hole placeholder, no failed-restore.
+    #[cfg(target_os = "macos")]
+    pub fn reconcile_syphon(&mut self) {
+        const SCAN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+        if self.external_io.last_syphon_scan.elapsed() < SCAN_INTERVAL {
+            return;
+        }
+        self.external_io.last_syphon_scan = std::time::Instant::now();
+
+        // (1) Re-scan. Cheap directory query; safe to run every tick-second.
+        self.external_io.syphon_manager.discover();
+
+        if self.external_io.pending_syphon.is_empty() {
+            return;
+        }
+
+        // (2) Bind any pending deck whose server is now available.
+        let available: std::collections::HashSet<String> = self
+            .external_io
+            .syphon_manager
+            .sources()
+            .iter()
+            .map(|s| s.name.clone())
+            .collect();
+
+        // Pull the ready ones out; leave the rest pending for the next pass.
+        let mut ready: Vec<crate::persistence::PendingSyphonDeck> = Vec::new();
+        self.external_io
+            .pending_syphon
+            .retain(|p| match &p.config.source {
+                crate::scene::SourceConfig::Syphon { name } if available.contains(name) => {
+                    ready.push(p.clone());
+                    false
+                }
+                _ => true,
+            });
+
+        for p in ready {
+            let crate::scene::SourceConfig::Syphon { name } = &p.config.source else {
+                continue;
+            };
+            let server_name = name.clone();
+            let ch_idx = p.channel_idx;
+            match self.cmd_add_syphon_deck(ch_idx, server_name.clone()) {
+                CommandResult::Ok
+                | CommandResult::OkWithId { .. }
+                | CommandResult::OkWithData { .. } => {
+                    // Re-apply the persisted slot props onto the deck we just bound
+                    // (matched by name so an idempotent no-op doesn't mis-target).
+                    let display_name = format!("🔗 {}", server_name);
+                    if let Some(ch) = self.mixer.channel_mut(ch_idx) {
+                        if let Some(slot) = ch
+                            .decks
+                            .iter_mut()
+                            .find(|s| s.deck.source_name() == display_name)
+                        {
+                            slot.opacity = p.config.opacity;
+                            slot.blend_mode = p.config.blend_mode.into();
+                            slot.mute = p.config.mute;
+                            slot.solo = p.config.solo;
+                            slot.z_index = p.config.z_index;
+                        }
+                    }
+                    log::info!(
+                        "Syphon deck '{}' late-bound to channel {}",
+                        server_name,
+                        ch_idx
+                    );
+                }
+                CommandResult::Err { message, .. } => {
+                    log::warn!(
+                        "Syphon late-bind for '{}' (channel {}) failed: {}; will retry",
+                        server_name,
+                        ch_idx,
+                        message
+                    );
+                    // Requeue to retry on the next reconcile.
+                    self.external_io.pending_syphon.push(p);
+                }
+            }
+        }
     }
 }

--- a/src/app/state/io.rs
+++ b/src/app/state/io.rs
@@ -56,6 +56,25 @@ impl VardaApp {
     ) -> CommandResult {
         #[cfg(target_os = "macos")]
         {
+            // Idempotency: if this channel already carries a Syphon deck for this
+            // server, do nothing. An external controller may re-subscribe on every
+            // reconnect, and our own reconcile may also bind it — both must
+            // converge to a single deck, not stack duplicates.
+            let display_name = format!("🔗 {}", server_name);
+            if let Some(ch) = self.mixer.channels().get(channel_idx) {
+                if ch
+                    .decks
+                    .iter()
+                    .any(|s| s.deck.source_name() == display_name)
+                {
+                    log::debug!(
+                        "Syphon deck '{}' already present on channel {}; add is a no-op",
+                        server_name,
+                        channel_idx
+                    );
+                    return CommandResult::Ok;
+                }
+            }
             match self
                 .external_io
                 .syphon_manager
@@ -422,5 +441,98 @@ impl VardaApp {
     pub fn cmd_remove_html_library_entry(&mut self, url: String) -> CommandResult {
         self.external_io.html_library.retain(|u| u != &url);
         CommandResult::Ok
+    }
+
+    /// Render-thread Syphon maintenance, called ~1×/sec (see `render_mixer_frame`).
+    ///
+    /// Two jobs, both removing the start/stop-ordering fragility that used to
+    /// require coordinated launch and manual re-probes:
+    ///   1. **Auto-rediscover** — re-scan `SyphonServerDirectory` so a producer
+    ///      that starts, restarts, or republishes *after* Varda is noticed
+    ///      without an external rescan poke. Keeps the snapshot/library list
+    ///      fresh for the UI and any external controller's GET fallback.
+    ///   2. **Late-bind pending decks** — any Syphon deck deferred at restore
+    ///      time (`persistence::PendingSyphonDeck`) is attached the moment its
+    ///      named server appears. No black_hole placeholder, no failed-restore.
+    #[cfg(target_os = "macos")]
+    pub fn reconcile_syphon(&mut self) {
+        const SCAN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+        if self.external_io.last_syphon_scan.elapsed() < SCAN_INTERVAL {
+            return;
+        }
+        self.external_io.last_syphon_scan = std::time::Instant::now();
+
+        // (1) Re-scan. Cheap directory query; safe to run every tick-second.
+        self.external_io.syphon_manager.discover();
+
+        if self.external_io.pending_syphon.is_empty() {
+            return;
+        }
+
+        // (2) Bind any pending deck whose server is now available.
+        let available: std::collections::HashSet<String> = self
+            .external_io
+            .syphon_manager
+            .sources()
+            .iter()
+            .map(|s| s.name.clone())
+            .collect();
+
+        // Pull the ready ones out; leave the rest pending for the next pass.
+        let mut ready: Vec<crate::persistence::PendingSyphonDeck> = Vec::new();
+        self.external_io
+            .pending_syphon
+            .retain(|p| match &p.config.source {
+                crate::scene::SourceConfig::Syphon { name } if available.contains(name) => {
+                    ready.push(p.clone());
+                    false
+                }
+                _ => true,
+            });
+
+        for p in ready {
+            let crate::scene::SourceConfig::Syphon { name } = &p.config.source else {
+                continue;
+            };
+            let server_name = name.clone();
+            let ch_idx = p.channel_idx;
+            match self.cmd_add_syphon_deck(ch_idx, server_name.clone()) {
+                CommandResult::Ok
+                | CommandResult::OkWithId { .. }
+                | CommandResult::OkWithData { .. } => {
+                    // Re-apply the persisted slot props onto the deck we just bound
+                    // (matched by name so an idempotent no-op doesn't mis-target).
+                    let display_name = format!("🔗 {}", server_name);
+                    if let Some(ch) = self.mixer.channel_mut(ch_idx) {
+                        if let Some(slot) = ch
+                            .decks
+                            .iter_mut()
+                            .find(|s| s.deck.source_name() == display_name)
+                        {
+                            slot.opacity = p.config.opacity;
+                            slot.blend_mode = p.config.blend_mode.into();
+                            slot.mute = p.config.mute;
+                            slot.solo = p.config.solo;
+                            slot.z_index = p.config.z_index;
+                        }
+                    }
+                    log::info!(
+                        "Syphon deck '{}' late-bound to channel {}",
+                        server_name,
+                        ch_idx
+                    );
+                }
+                CommandResult::Err { message, .. } => {
+                    log::warn!(
+                        "Syphon late-bind for '{}' (channel {}) failed: {}; will retry",
+                        server_name,
+                        ch_idx,
+                        message
+                    );
+                    // Requeue to retry on the next reconcile.
+                    self.external_io.pending_syphon.push(p);
+                }
+            }
+        }
     }
 }

--- a/src/app/state/outputs.rs
+++ b/src/app/state/outputs.rs
@@ -164,14 +164,36 @@ impl VardaApp {
                     audio_input,
                 )
             }
-            OutputTarget::NdiSend { .. } | OutputTarget::SyphonServer { .. } => {
-                // No ffmpeg subprocess; NDI/Syphon don't carry passthrough audio.
+            OutputTarget::NdiSend { .. } => {
+                // No ffmpeg subprocess; NDI doesn't carry passthrough audio.
                 self.release_passthrough(passthrough);
                 if let Some(UnifiedOutput::Headless(h)) = self.output.outputs.get_mut(idx) {
                     h.active = true;
                     h.started_at = Some(std::time::Instant::now());
                 }
                 return CommandResult::Ok;
+            }
+            OutputTarget::SyphonServer { .. } => {
+                // No ffmpeg subprocess; Syphon doesn't carry passthrough audio.
+                self.release_passthrough(passthrough);
+                #[cfg(target_os = "macos")]
+                {
+                    if let Some(UnifiedOutput::Headless(h)) = self.output.outputs.get_mut(idx) {
+                        h.active = true;
+                        h.started_at = Some(std::time::Instant::now());
+                    }
+                    return CommandResult::Ok;
+                }
+                // Parity with the Syphon receive path (cmd_add_syphon_deck): reject
+                // explicitly on non-macOS so an API client gets clear feedback rather
+                // than a silently inert output.
+                #[cfg(not(target_os = "macos"))]
+                {
+                    return CommandResult::Err {
+                        code: ErrorCode::Unavailable,
+                        message: "Syphon is only available on macOS".into(),
+                    };
+                }
             }
             _ => {
                 self.release_passthrough(passthrough);

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -176,6 +176,19 @@ impl VardaApp {
                             for warn in &result.warnings {
                                 self.session.notifications.warn(warn.clone());
                             }
+                            // Syphon decks that could not resolve at restore time
+                            // (producer not publishing yet) — the render thread
+                            // auto-binds them as their servers appear.
+                            #[cfg(target_os = "macos")]
+                            {
+                                if !result.pending_syphon.is_empty() {
+                                    log::info!(
+                                        "{} Syphon deck(s) deferred to late-bind",
+                                        result.pending_syphon.len()
+                                    );
+                                }
+                                self.external_io.pending_syphon = result.pending_syphon;
+                            }
 
                             // Start preprocessor analyzers for active decks restored from save.
                             // A deck is "active" when it is not muted and has non-zero opacity.

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -177,6 +177,19 @@ impl VardaApp {
                             for warn in &result.warnings {
                                 self.session.notifications.warn(warn.clone());
                             }
+                            // Syphon decks that could not resolve at restore time
+                            // (producer not publishing yet) — the render thread
+                            // auto-binds them as their servers appear.
+                            #[cfg(target_os = "macos")]
+                            {
+                                if !result.pending_syphon.is_empty() {
+                                    log::info!(
+                                        "{} Syphon deck(s) deferred to late-bind",
+                                        result.pending_syphon.len()
+                                    );
+                                }
+                                self.external_io.pending_syphon = result.pending_syphon;
+                            }
 
                             // Start preprocessor analyzers for active decks restored from save.
                             // A deck is "active" when it is not muted and has non-zero opacity.

--- a/src/internal/persistence/mod.rs
+++ b/src/internal/persistence/mod.rs
@@ -850,6 +850,9 @@ pub fn restore_scene(
     render_height: u32,
 ) -> Result<RestoreResult> {
     let mut warnings = Vec::new();
+    // Only pushed to under #[cfg(target_os = "macos")]; on other platforms it
+    // stays empty, so `mut` would be flagged as unused there.
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut pending_syphon: Vec<PendingSyphonDeck> = Vec::new();
     let mut mixer = Mixer::new(context, render_width, render_height)?;
 

--- a/src/internal/persistence/mod.rs
+++ b/src/internal/persistence/mod.rs
@@ -819,11 +819,29 @@ use crate::deck::{Deck, Effect};
 use crate::isf::ISFShader;
 use crate::renderer::GpuContext;
 
+/// A Syphon deck whose source could not be resolved at restore time, deferred
+/// for late binding. Varda is the *client* of externally-owned Syphon servers;
+/// on restart the producer may not be publishing yet, so the named server is not in
+/// `SyphonServerDirectory`. Rather than fail the restore (the old behaviour:
+/// "restoration not yet implemented" → black_hole placeholder), we record the
+/// intent here and let `VardaApp::reconcile_syphon` auto-attach the real deck
+/// the moment the server appears. Startup order becomes irrelevant.
+#[derive(Debug, Clone)]
+pub struct PendingSyphonDeck {
+    /// Channel index (position in the restored channel list) this deck belongs to.
+    pub channel_idx: usize,
+    /// Full persisted deck config (carries the `Syphon { name }` source plus
+    /// opacity / blend / mute / solo / z-index to re-apply on bind).
+    pub config: crate::scene::DeckConfig,
+}
+
 /// Restore result — contains reconstructed mixer.
 /// Surfaces and outputs are loaded separately from stage.json.
 pub struct RestoreResult {
     pub mixer: Mixer,
     pub warnings: Vec<String>,
+    /// Syphon decks deferred for late binding (see `PendingSyphonDeck`).
+    pub pending_syphon: Vec<PendingSyphonDeck>,
 }
 
 /// Reconstruct live state from a SceneConfig.
@@ -841,12 +859,13 @@ pub fn restore_scene(
     render_height: u32,
 ) -> Result<RestoreResult> {
     let mut warnings = Vec::new();
+    let mut pending_syphon: Vec<PendingSyphonDeck> = Vec::new();
     let mut mixer = Mixer::new(context, render_width, render_height)?;
 
     // Clear default channels — we'll create from config
     mixer.channels_mut().clear();
 
-    for ch_config in &config.channels {
+    for (ch_idx, ch_config) in config.channels.iter().enumerate() {
         let mut channel = crate::channel::Channel::new(
             ch_config.name.clone(),
             context,
@@ -860,6 +879,33 @@ pub fn restore_scene(
         channel.blend_mode = ch_config.blend_mode.into();
 
         for deck_config in &ch_config.decks {
+            // Externally-owned Syphon decks are resolved at runtime, not at
+            // restore time — the producer may not be publishing yet. Defer to a
+            // pending binding the render thread auto-attaches
+            // once the named server appears (see VardaApp::reconcile_syphon).
+            // This replaces the old hard-fail stub that dropped the channel to a
+            // black_hole placeholder and spammed "restoration not yet implemented".
+            if let SourceConfig::Syphon { name } = &deck_config.source {
+                #[cfg(target_os = "macos")]
+                {
+                    log::info!(
+                        "Syphon deck '{}' on channel {} deferred to late-bind \
+                         (auto-attaches when the server appears)",
+                        name,
+                        ch_idx
+                    );
+                    pending_syphon.push(PendingSyphonDeck {
+                        channel_idx: ch_idx,
+                        config: deck_config.clone(),
+                    });
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let _ = ch_idx;
+                    log::debug!("Skipping Syphon deck '{}' on non-macOS restore", name);
+                }
+                continue;
+            }
             match restore_deck(
                 deck_config,
                 context,
@@ -1077,7 +1123,11 @@ pub fn restore_scene(
         }
     }
 
-    Ok(RestoreResult { mixer, warnings })
+    Ok(RestoreResult {
+        mixer,
+        warnings,
+        pending_syphon,
+    })
 }
 
 /// Restore a single deck from config.

--- a/src/internal/persistence/mod.rs
+++ b/src/internal/persistence/mod.rs
@@ -859,6 +859,9 @@ pub fn restore_scene(
     render_height: u32,
 ) -> Result<RestoreResult> {
     let mut warnings = Vec::new();
+    // Only pushed to under #[cfg(target_os = "macos")]; on other platforms it
+    // stays empty, so `mut` would be flagged as unused there.
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut pending_syphon: Vec<PendingSyphonDeck> = Vec::new();
     let mut mixer = Mixer::new(context, render_width, render_height)?;
 

--- a/src/internal/persistence/mod.rs
+++ b/src/internal/persistence/mod.rs
@@ -811,11 +811,29 @@ use crate::deck::{Deck, Effect};
 use crate::isf::ISFShader;
 use crate::renderer::GpuContext;
 
+/// A Syphon deck whose source could not be resolved at restore time, deferred
+/// for late binding. Varda is the *client* of externally-owned Syphon servers;
+/// on restart the producer may not be publishing yet, so the named server is not in
+/// `SyphonServerDirectory`. Rather than fail the restore (the old behaviour:
+/// "restoration not yet implemented" → black_hole placeholder), we record the
+/// intent here and let `VardaApp::reconcile_syphon` auto-attach the real deck
+/// the moment the server appears. Startup order becomes irrelevant.
+#[derive(Debug, Clone)]
+pub struct PendingSyphonDeck {
+    /// Channel index (position in the restored channel list) this deck belongs to.
+    pub channel_idx: usize,
+    /// Full persisted deck config (carries the `Syphon { name }` source plus
+    /// opacity / blend / mute / solo / z-index to re-apply on bind).
+    pub config: crate::scene::DeckConfig,
+}
+
 /// Restore result — contains reconstructed mixer.
 /// Surfaces and outputs are loaded separately from stage.json.
 pub struct RestoreResult {
     pub mixer: Mixer,
     pub warnings: Vec<String>,
+    /// Syphon decks deferred for late binding (see `PendingSyphonDeck`).
+    pub pending_syphon: Vec<PendingSyphonDeck>,
 }
 
 /// Reconstruct live state from a SceneConfig.
@@ -832,12 +850,13 @@ pub fn restore_scene(
     render_height: u32,
 ) -> Result<RestoreResult> {
     let mut warnings = Vec::new();
+    let mut pending_syphon: Vec<PendingSyphonDeck> = Vec::new();
     let mut mixer = Mixer::new(context, render_width, render_height)?;
 
     // Clear default channels — we'll create from config
     mixer.channels_mut().clear();
 
-    for ch_config in &config.channels {
+    for (ch_idx, ch_config) in config.channels.iter().enumerate() {
         let mut channel = crate::channel::Channel::new(
             ch_config.name.clone(),
             context,
@@ -851,6 +870,33 @@ pub fn restore_scene(
         channel.blend_mode = ch_config.blend_mode.into();
 
         for deck_config in &ch_config.decks {
+            // Externally-owned Syphon decks are resolved at runtime, not at
+            // restore time — the producer may not be publishing yet. Defer to a
+            // pending binding the render thread auto-attaches
+            // once the named server appears (see VardaApp::reconcile_syphon).
+            // This replaces the old hard-fail stub that dropped the channel to a
+            // black_hole placeholder and spammed "restoration not yet implemented".
+            if let SourceConfig::Syphon { name } = &deck_config.source {
+                #[cfg(target_os = "macos")]
+                {
+                    log::info!(
+                        "Syphon deck '{}' on channel {} deferred to late-bind \
+                         (auto-attaches when the server appears)",
+                        name,
+                        ch_idx
+                    );
+                    pending_syphon.push(PendingSyphonDeck {
+                        channel_idx: ch_idx,
+                        config: deck_config.clone(),
+                    });
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let _ = ch_idx;
+                    log::debug!("Skipping Syphon deck '{}' on non-macOS restore", name);
+                }
+                continue;
+            }
             match restore_deck(
                 deck_config,
                 context,
@@ -1067,7 +1113,11 @@ pub fn restore_scene(
         }
     }
 
-    Ok(RestoreResult { mixer, warnings })
+    Ok(RestoreResult {
+        mixer,
+        warnings,
+        pending_syphon,
+    })
 }
 
 /// Restore a single deck from config.

--- a/src/internal/renderer/context.rs
+++ b/src/internal/renderer/context.rs
@@ -1384,7 +1384,6 @@ impl HeadlessOutput {
         &mut self,
         frame_data: &[u8],
         ndi_manager: &mut crate::ndi::NdiManager,
-        #[cfg(target_os = "macos")] syphon_manager: &mut crate::syphon::SyphonManager,
     ) -> DeliveryResult {
         match &mut self.target {
             OutputTarget::Recording { .. }
@@ -1422,11 +1421,8 @@ impl HeadlessOutput {
                 ndi_manager.send_frame(sender_name, frame_data, self.width, self.height);
                 DeliveryResult::Ok
             }
-            #[cfg(target_os = "macos")]
-            OutputTarget::SyphonServer { .. } => {
-                syphon_manager.publish_frame(frame_data, self.width, self.height);
-                DeliveryResult::Ok
-            }
+            // Syphon output is published GPU-side (zero-copy) in the headless
+            // render loop before this point, so on macOS it never reaches here.
             #[cfg(not(target_os = "macos"))]
             OutputTarget::SyphonServer { .. } => {
                 log::warn!("Syphon output not supported on this platform");

--- a/src/internal/syphon/mod.rs
+++ b/src/internal/syphon/mod.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, OnceLock,
+    Arc, Mutex, OnceLock,
 };
 use std::thread::JoinHandle;
 
@@ -75,47 +75,6 @@ extern_class!(
 const KEY_NAME: &str = "SyphonServerDescriptionNameKey";
 const KEY_APP: &str = "SyphonServerDescriptionAppNameKey";
 
-use objc2::rc::Retained;
-use objc2::runtime::{AnyObject, ProtocolObject};
-use objc2::{extern_class, msg_send, AnyThread, ClassType};
-use objc2_foundation::{NSArray, NSDictionary, NSString};
-use objc2_metal::{
-    MTLCreateSystemDefaultDevice, MTLDevice, MTLOrigin, MTLRegion, MTLSize, MTLTexture,
-};
-
-// ---------------------------------------------------------------------------
-// Syphon.framework FFI. These classes are vended by Syphon.framework (loaded at
-// runtime via dlopen), declared here as opaque NSObject subclasses.
-//
-// SyphonServerDirectory.h:
-//   + (SyphonServerDirectory *)sharedDirectory;
-//   - (NSArray<NSDictionary *> *)serversMatchingName:(NSString *)name
-//                                              appName:(NSString *)appName;
-// SyphonMetalClient.h:
-//   - initWithServerDescription:(NSDictionary *)desc device:(id<MTLDevice>)dev
-//                       options:(NSDictionary *)opts
-//               newFrameHandler:(void (^)(SyphonMetalClient *))handler;
-//   - (id<MTLTexture>)newFrameImage;
-//   - (void)stop;
-// ---------------------------------------------------------------------------
-extern_class!(
-    #[unsafe(super(objc2::runtime::NSObject))]
-    #[name = "SyphonServerDirectory"]
-    pub struct SyphonServerDirectory;
-);
-
-extern_class!(
-    #[unsafe(super(objc2::runtime::NSObject))]
-    #[name = "SyphonMetalClient"]
-    pub struct SyphonMetalClient;
-);
-
-// Syphon server-description dictionary keys. The framework exports these as
-// extern NSString constants; we reconstruct them from their documented values
-// to avoid an extern-static binding.
-const KEY_NAME: &str = "SyphonServerDescriptionNameKey";
-const KEY_APP: &str = "SyphonServerDescriptionAppNameKey";
-
 /// Discovered Syphon server.
 #[derive(Debug, Clone)]
 pub struct SyphonSource {
@@ -125,38 +84,13 @@ pub struct SyphonSource {
     pub app_name: String,
 }
 
-<<<<<<< HEAD
 /// Latest decoded frame handed from a receive thread to the render thread.
 struct SyphonFrame {
     data: Vec<u8>,
-=======
-/// Manages Syphon server discovery and client connections.
-pub struct SyphonManager {
-    available: bool,
-    sources: Vec<SyphonSource>,
-    /// Server-description dicts kept alongside `sources` by name, needed to init
-    /// a `SyphonMetalClient`.
-    descriptions: Vec<(String, Retained<NSDictionary<NSString, AnyObject>>)>,
-    clients: Vec<SyphonClient>,
-    textures: Vec<(wgpu::Texture, wgpu::TextureView)>,
-    /// Our own Metal device for the clients (one GPU on M-series). Lazily created.
-    metal_device: Option<Retained<ProtocolObject<dyn MTLDevice>>>,
-    /// wgpu device clone, captured at first `start_receive`, so `update()` can
-    /// (re)create textures when a server's frame size becomes known/changes.
-    device: Option<wgpu::Device>,
-}
-
-struct SyphonClient {
-    #[allow(dead_code)]
-    server_name: String,
-    client: Retained<SyphonMetalClient>,
-    stop_flag: Arc<AtomicBool>,
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
     width: u32,
     height: u32,
 }
 
-<<<<<<< HEAD
 /// Manages Syphon server discovery, client receivers, and server publishers.
 pub struct SyphonManager {
     available: bool,
@@ -282,10 +216,6 @@ impl PublishScheduler {
 // the retained server descriptions are render-thread-only; receiver Metal
 // clients live on their own threads and are never stored here. Nothing is shared
 // across threads, so asserting Send is sound.
-=======
-// Single-threaded ownership: the manager lives on (and is only touched from)
-// varda's render thread. Metal objects aren't Sync but are never shared.
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
 unsafe impl Send for SyphonManager {}
 
 impl Default for SyphonManager {
@@ -306,7 +236,6 @@ impl SyphonManager {
             available,
             sources: Vec::new(),
             descriptions: Vec::new(),
-<<<<<<< HEAD
             receivers: Vec::new(),
             textures: Vec::new(),
             metal_device: None,
@@ -314,12 +243,6 @@ impl SyphonManager {
             publish_queue: None,
             convert_pipeline: None,
             servers: HashMap::new(),
-=======
-            clients: Vec::new(),
-            textures: Vec::new(),
-            metal_device: None,
-            device: None,
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
         }
     }
 
@@ -386,22 +309,16 @@ impl SyphonManager {
         log::debug!("Syphon discover: {} server(s)", self.sources.len());
     }
 
-<<<<<<< HEAD
     /// Start receiving from a named Syphon server. Spawns a dedicated receive
     /// thread (`syphon-recv-{name}`) that owns the `SyphonMetalClient`, polls
     /// `newFrameImage`, performs the `getBytes` CPU readback off the render
     /// thread, and publishes RGBA into `frame_data`. Returns a client index used
     /// by `texture_view()` / `client_dimensions()`.
-=======
-    /// Start receiving from a named Syphon server. Returns a client index used by
-    /// `texture_view()` / `client_dimensions()`.
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
     pub fn start_receive(&mut self, server_name: &str, device: &wgpu::Device) -> Option<usize> {
         if !self.available {
             log::warn!("Cannot receive Syphon: framework not available");
             return None;
         }
-<<<<<<< HEAD
 
         // The description must be resolved here (render thread): SyphonServerDirectory
         // observes distributed notifications on the render-thread run loop.
@@ -445,40 +362,6 @@ impl SyphonManager {
         let stop_clone = Arc::clone(&stop_flag);
         let connected_clone = Arc::clone(&connected);
         let name_log = server_name.to_string();
-=======
-        if self.device.is_none() {
-            self.device = Some(device.clone());
-        }
-
-        let desc = self
-            .descriptions
-            .iter()
-            .find(|(n, _)| n == server_name)
-            .map(|(_, d)| d.clone());
-        let Some(desc) = desc else {
-            log::warn!("Syphon: no discovered server named '{}'", server_name);
-            return None;
-        };
-
-        let metal = self.metal_device()?.clone();
-        let client: Retained<SyphonMetalClient> = unsafe {
-            let alloc = SyphonMetalClient::alloc();
-            let nil_opts: *const NSDictionary<NSString, AnyObject> = std::ptr::null();
-            // newFrameHandler: nil — we poll in update() instead of using the block.
-            let handler: *const AnyObject = std::ptr::null();
-            msg_send![
-                alloc,
-                initWithServerDescription: &*desc,
-                device: &*metal,
-                options: nil_opts,
-                newFrameHandler: handler,
-            ]
-        };
-
-        // Placeholder size; corrected on the first frame in update().
-        let (width, height) = (1920u32, 1080u32);
-        let (texture, view) = make_texture(device, server_name, width, height);
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
 
         let thread = std::thread::Builder::new()
             .name(format!("syphon-recv-{}", server_name))
@@ -508,15 +391,10 @@ impl SyphonManager {
         let idx = self.receivers.len();
         self.receivers.push(SyphonReceiver {
             server_name: server_name.to_string(),
-<<<<<<< HEAD
             frame_data,
             stop_flag,
             connected,
             thread,
-=======
-            client,
-            stop_flag: Arc::new(AtomicBool::new(false)),
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
             width,
             height,
         });
@@ -525,7 +403,6 @@ impl SyphonManager {
         Some(idx)
     }
 
-<<<<<<< HEAD
     /// Pull the newest frame from each receive thread and upload it to its wgpu
     /// texture. Render-thread, upload-only: non-blocking `try_lock` + `take` +
     /// `write_texture`, recreating the texture when the server's frame size changes.
@@ -536,34 +413,6 @@ impl SyphonManager {
                     guard.take()
                 } else {
                     None
-=======
-    /// Pull the newest frame from each client and upload it to its wgpu texture.
-    /// Runs on the render thread (callers already hold `&mut self`).
-    pub fn update(&mut self, queue: &wgpu::Queue) {
-        for i in 0..self.clients.len() {
-            if self.clients[i].stop_flag.load(Ordering::Relaxed) {
-                continue;
-            }
-            // Latest completed frame, or None if nothing new.
-            let tex: Option<Retained<ProtocolObject<dyn MTLTexture>>> =
-                unsafe { msg_send![&self.clients[i].client, newFrameImage] };
-            let Some(tex) = tex else { continue };
-
-            let w = tex.width() as u32;
-            let h = tex.height() as u32;
-            if w == 0 || h == 0 {
-                continue;
-            }
-
-            // Resize the wgpu texture if the server's frame size changed.
-            if w != self.clients[i].width || h != self.clients[i].height {
-                if let Some(dev) = self.device.clone() {
-                    let name = self.clients[i].server_name.clone();
-                    let (t, v) = make_texture(&dev, &name, w, h);
-                    self.textures[i] = (t, v);
-                    self.clients[i].width = w;
-                    self.clients[i].height = h;
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
                 }
             };
             let Some(frame) = new_frame else { continue };
@@ -572,7 +421,6 @@ impl SyphonManager {
                 continue;
             }
 
-<<<<<<< HEAD
             // Recreate the wgpu texture if the server's frame size changed.
             if w != self.receivers[i].width || h != self.receivers[i].height {
                 let name = self.receivers[i].server_name.clone();
@@ -586,29 +434,6 @@ impl SyphonManager {
             if frame.data.len() < expected {
                 continue;
             }
-=======
-            // CPU readback from the IOSurface-backed Metal texture.
-            // NOTE: requires the source texture to be Shared/Managed storage
-            // (Syphon's surface textures are Shared on Apple silicon).
-            let mut buf = vec![0u8; (w * h * 4) as usize];
-            let region = MTLRegion {
-                origin: MTLOrigin { x: 0, y: 0, z: 0 },
-                size: MTLSize {
-                    width: w as usize,
-                    height: h as usize,
-                    depth: 1,
-                },
-            };
-            unsafe {
-                tex.getBytes_bytesPerRow_fromRegion_mipmapLevel(
-                    std::ptr::NonNull::new(buf.as_mut_ptr() as *mut std::ffi::c_void).unwrap(),
-                    (w * 4) as usize,
-                    region,
-                    0,
-                );
-            }
-
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
             queue.write_texture(
                 wgpu::TexelCopyTextureInfo {
                     texture: &self.textures[i].0,
@@ -616,11 +441,7 @@ impl SyphonManager {
                     origin: wgpu::Origin3d::ZERO,
                     aspect: wgpu::TextureAspect::All,
                 },
-<<<<<<< HEAD
                 &frame.data[..expected],
-=======
-                &buf,
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
                 wgpu::TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(w * 4),
@@ -643,7 +464,6 @@ impl SyphonManager {
         self.receivers.get(idx).map(|c| (c.width, c.height))
     }
 
-<<<<<<< HEAD
     /// Whether the receive thread for `idx` is currently getting frames.
     pub fn is_connected(&self, idx: usize) -> bool {
         self.receivers
@@ -896,16 +716,6 @@ impl SyphonManager {
             r.stop_flag.store(true, Ordering::SeqCst);
             if let Some(t) = r.thread.take() {
                 let _ = t.join();
-=======
-    /// Publishing from varda is out of scope here (varda is the client).
-    pub fn publish_frame(&mut self, _rgba: &[u8], _width: u32, _height: u32) {}
-
-    pub fn stop_receive(&mut self, idx: usize) {
-        if let Some(c) = self.clients.get_mut(idx) {
-            c.stop_flag.store(true, Ordering::SeqCst);
-            unsafe {
-                let _: () = msg_send![&c.client, stop];
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
             }
         }
     }
@@ -915,7 +725,6 @@ impl SyphonManager {
     }
 }
 
-<<<<<<< HEAD
 /// Receive loop body, run on a dedicated `syphon-recv-*` thread. Polls the
 /// client for new frames, performs the CPU readback, and swaps RGBA into
 /// `frame_data`. Tracks a `connected` flag: a producer that stops publishing is
@@ -985,8 +794,6 @@ fn syphon_receive_loop(
     }
 }
 
-=======
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
 /// dlopen Syphon.framework once and keep it loaded for the process lifetime.
 ///
 /// We load at runtime (via libloading, already a varda dep) rather than linking
@@ -1058,17 +865,10 @@ fn make_texture(
 
 impl Drop for SyphonManager {
     fn drop(&mut self) {
-<<<<<<< HEAD
         for r in &mut self.receivers {
             r.stop_flag.store(true, Ordering::SeqCst);
             if let Some(t) = r.thread.take() {
                 let _ = t.join();
-=======
-        for c in &mut self.clients {
-            c.stop_flag.store(true, Ordering::SeqCst);
-            unsafe {
-                let _: () = msg_send![&c.client, stop];
->>>>>>> refs/remotes/dancemore/pr/syphon-receiver
             }
         }
         for h in self.servers.values() {
@@ -1184,58 +984,5 @@ mod tests {
         assert_eq!(s.poll_write(), None);
         assert_eq!(s.poll_publish(&[true, false]), Some(0));
         assert_eq!(s.poll_write(), Some(1));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // These exercise the host-independent paths only: a fresh manager holds no
-    // clients/sources, so none of these touch Syphon.framework or Metal. They
-    // pass whether or not Syphon is installed on the test machine.
-
-    #[test]
-    fn syphon_manager_new_no_crash() {
-        // new() probes for Syphon.framework; on machines without it, `available`
-        // is simply false. Just verify construction and the query don't panic.
-        let mgr = SyphonManager::new();
-        let _ = mgr.is_available();
-    }
-
-    #[test]
-    fn syphon_manager_disabled_is_unavailable() {
-        let mgr = SyphonManager::new_disabled();
-        assert!(!mgr.is_available());
-    }
-
-    #[test]
-    fn syphon_manager_sources_empty() {
-        let mgr = SyphonManager::new();
-        assert!(mgr.sources().is_empty());
-        assert!(mgr.discovered_sources().is_empty());
-    }
-
-    #[test]
-    fn syphon_manager_texture_view_out_of_bounds() {
-        let mgr = SyphonManager::new();
-        assert!(mgr.texture_view(0).is_none());
-        assert!(mgr.texture_view(999).is_none());
-    }
-
-    #[test]
-    fn syphon_manager_client_dimensions_out_of_bounds() {
-        let mgr = SyphonManager::new();
-        assert!(mgr.client_dimensions(0).is_none());
-        assert!(mgr.client_dimensions(999).is_none());
-    }
-
-    #[test]
-    fn syphon_manager_discover_noop_when_unavailable() {
-        // discover() early-returns when the framework is absent; on a machine
-        // with Syphon it may populate sources, but must never panic either way.
-        let mut mgr = SyphonManager::new_disabled();
-        mgr.discover();
-        assert!(mgr.sources().is_empty());
     }
 }

--- a/src/internal/syphon/mod.rs
+++ b/src/internal/syphon/mod.rs
@@ -12,17 +12,21 @@
 //! `framework_loaded`), not linked — a Mac without Syphon installed still builds
 //! and runs, with Syphon features disabled.
 
+use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, OnceLock,
+    Arc, Mutex, OnceLock,
 };
+use std::thread::JoinHandle;
 
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{extern_class, msg_send, AnyThread, ClassType};
-use objc2_foundation::{NSArray, NSDictionary, NSString};
+use objc2_foundation::{NSArray, NSDictionary, NSPoint, NSRect, NSSize, NSString};
 use objc2_metal::{
-    MTLCreateSystemDefaultDevice, MTLDevice, MTLOrigin, MTLRegion, MTLSize, MTLTexture,
+    MTLCommandBuffer, MTLCommandQueue, MTLCreateSystemDefaultDevice, MTLDevice, MTLOrigin,
+    MTLPixelFormat, MTLRegion, MTLSize, MTLStorageMode, MTLTexture, MTLTextureDescriptor,
+    MTLTextureType, MTLTextureUsage,
 };
 
 // ---------------------------------------------------------------------------
@@ -52,6 +56,19 @@ extern_class!(
     pub struct SyphonMetalClient;
 );
 
+// SyphonMetalServer.h (sender side):
+//   - initWithName:(NSString *)name device:(id<MTLDevice>)device
+//                  options:(NSDictionary *)options;
+//   - (void)publishFrameTexture:(id<MTLTexture>)tex
+//                  onCommandBuffer:(id<MTLCommandBuffer>)cb
+//                      imageRegion:(NSRect)region flipped:(BOOL)isFlipped;
+//   - (void)stop;
+extern_class!(
+    #[unsafe(super(objc2::runtime::NSObject))]
+    #[name = "SyphonMetalServer"]
+    pub struct SyphonMetalServer;
+);
+
 // Syphon server-description dictionary keys. The framework exports these as
 // extern NSString constants; we reconstruct them from their documented values
 // to avoid an extern-static binding.
@@ -67,33 +84,138 @@ pub struct SyphonSource {
     pub app_name: String,
 }
 
-/// Manages Syphon server discovery and client connections.
-pub struct SyphonManager {
-    available: bool,
-    sources: Vec<SyphonSource>,
-    /// Server-description dicts kept alongside `sources` by name, needed to init
-    /// a `SyphonMetalClient`.
-    descriptions: Vec<(String, Retained<NSDictionary<NSString, AnyObject>>)>,
-    clients: Vec<SyphonClient>,
-    textures: Vec<(wgpu::Texture, wgpu::TextureView)>,
-    /// Our own Metal device for the clients (one GPU on M-series). Lazily created.
-    metal_device: Option<Retained<ProtocolObject<dyn MTLDevice>>>,
-    /// wgpu device clone, captured at first `start_receive`, so `update()` can
-    /// (re)create textures when a server's frame size becomes known/changes.
-    device: Option<wgpu::Device>,
-}
-
-struct SyphonClient {
-    #[allow(dead_code)]
-    server_name: String,
-    client: Retained<SyphonMetalClient>,
-    stop_flag: Arc<AtomicBool>,
+/// Latest decoded frame handed from a receive thread to the render thread.
+struct SyphonFrame {
+    data: Vec<u8>,
     width: u32,
     height: u32,
 }
 
-// Single-threaded ownership: the manager lives on (and is only touched from)
-// varda's render thread. Metal objects aren't Sync but are never shared.
+/// Manages Syphon server discovery, client receivers, and server publishers.
+pub struct SyphonManager {
+    available: bool,
+    sources: Vec<SyphonSource>,
+    /// Server-description dicts kept alongside `sources` by name, needed to init
+    /// a `SyphonMetalClient`. Looked up on the render thread in `start_receive`
+    /// because `SyphonServerDirectory` observes notifications on that run loop.
+    descriptions: Vec<(String, Retained<NSDictionary<NSString, AnyObject>>)>,
+    receivers: Vec<SyphonReceiver>,
+    textures: Vec<(wgpu::Texture, wgpu::TextureView)>,
+    /// Our own Metal device, shared by client init and publishers. Lazily created.
+    metal_device: Option<Retained<ProtocolObject<dyn MTLDevice>>>,
+    /// wgpu's own `MTLDevice`, extracted via `as_hal` so the publish textures,
+    /// the server, and the publish queue share one device — the basis for the
+    /// zero-copy (no readback) sender path. Lazily extracted on first publish.
+    wgpu_metal_device: Option<Retained<ProtocolObject<dyn MTLDevice>>>,
+    /// Command queue for publishing (sender side), on wgpu's device. Lazy.
+    publish_queue: Option<Retained<ProtocolObject<dyn MTLCommandQueue>>>,
+    /// RGBA→BGRA GPU conversion pipeline (sender side), replacing the old CPU
+    /// swizzle. Targets `Bgra8UnormSrgb`. Lazily built on first publish.
+    convert_pipeline: Option<crate::renderer::blit::BlitPipeline>,
+    /// Active Syphon publishers, keyed by server name (sender side). Created
+    /// lazily on first `publish_frame_gpu`. Render-thread only.
+    servers: HashMap<String, SyphonServerHandle>,
+}
+
+/// A background receive thread plus the render-thread-side wgpu texture it feeds.
+/// Mirrors `NdiReceiver`: the Metal client lives entirely on the receive thread;
+/// only RGBA bytes cross back via `frame_data`.
+struct SyphonReceiver {
+    #[allow(dead_code)]
+    server_name: String,
+    frame_data: Arc<Mutex<Option<SyphonFrame>>>,
+    stop_flag: Arc<AtomicBool>,
+    connected: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+    width: u32,
+    height: u32,
+}
+
+/// A Syphon publisher (sender side). The Metal server and its ring of publish
+/// textures live on the render thread, mirroring `NdiSender`. The conversion
+/// blit (RGBA→BGRA) renders into a ring slot via wgpu; Syphon then publishes
+/// that slot's native `MTLTexture` directly — no CPU readback, no CPU swizzle.
+struct SyphonServerHandle {
+    server: Retained<SyphonMetalServer>,
+    width: u32,
+    height: u32,
+    /// Ring of BGRA textures shared between wgpu (render) and Syphon (publish).
+    slots: Vec<PublishSlot>,
+    sched: PublishScheduler,
+}
+
+/// One publish texture, created on wgpu's `MTLDevice` and imported into wgpu so
+/// the conversion blit can render into it while Syphon reads the same native
+/// `MTLTexture`.
+struct PublishSlot {
+    /// Native handle handed to Syphon's `publishFrameTexture:`.
+    mtl: Retained<ProtocolObject<dyn MTLTexture>>,
+    /// The same texture imported into wgpu; kept alive so `view` stays valid.
+    _wgpu_texture: wgpu::Texture,
+    /// Render target for the conversion blit.
+    view: wgpu::TextureView,
+    /// Set true once this slot's blit submission completes on the GPU. Ensures
+    /// Syphon never reads a half-rendered texture (the write→read hazard).
+    write_done: Arc<AtomicBool>,
+}
+
+/// Number of publish textures per server. One is being rendered, one is pending
+/// publish, and the extra gives Syphon's in-flight read margin before the slot
+/// is reused (the softer read→overwrite hazard, mitigated by ring depth).
+const PUBLISH_RING: usize = 3;
+
+/// Round-robin scheduler decoupling GPU render (write) from Syphon publish.
+/// Pure index logic — unit-tested without a GPU. A slot is published only after
+/// its blit is GPU-complete, and never overwritten while pending publish.
+struct PublishScheduler {
+    n: usize,
+    write_cursor: usize,
+    /// Slot rendered-into but not yet published.
+    pending: Option<usize>,
+}
+
+impl PublishScheduler {
+    fn new(n: usize) -> Self {
+        Self {
+            n,
+            write_cursor: 0,
+            pending: None,
+        }
+    }
+
+    /// If a pending slot's blit has signalled completion, return it to publish
+    /// (clearing pending). `write_done[i]` reflects slot i's GPU completion.
+    fn poll_publish(&mut self, write_done: &[bool]) -> Option<usize> {
+        let p = self.pending?;
+        if write_done.get(p).copied().unwrap_or(false) {
+            self.pending = None;
+            Some(p)
+        } else {
+            None
+        }
+    }
+
+    /// Next slot to render into, or None if the previously rendered slot hasn't
+    /// been published yet (backpressure — drop the frame rather than clobber it).
+    fn poll_write(&mut self) -> Option<usize> {
+        if self.pending.is_some() {
+            return None;
+        }
+        let idx = self.write_cursor;
+        self.write_cursor = (self.write_cursor + 1) % self.n;
+        Some(idx)
+    }
+
+    fn mark_written(&mut self, idx: usize) {
+        self.pending = Some(idx);
+    }
+}
+
+// The manager lives on (and is only touched from) varda's render thread. The
+// publisher Metal objects (`servers`, `wgpu_metal_device`, `publish_queue`) and
+// the retained server descriptions are render-thread-only; receiver Metal
+// clients live on their own threads and are never stored here. Nothing is shared
+// across threads, so asserting Send is sound.
 unsafe impl Send for SyphonManager {}
 
 impl Default for SyphonManager {
@@ -114,10 +236,13 @@ impl SyphonManager {
             available,
             sources: Vec::new(),
             descriptions: Vec::new(),
-            clients: Vec::new(),
+            receivers: Vec::new(),
             textures: Vec::new(),
             metal_device: None,
-            device: None,
+            wgpu_metal_device: None,
+            publish_queue: None,
+            convert_pipeline: None,
+            servers: HashMap::new(),
         }
     }
 
@@ -184,17 +309,19 @@ impl SyphonManager {
         log::debug!("Syphon discover: {} server(s)", self.sources.len());
     }
 
-    /// Start receiving from a named Syphon server. Returns a client index used by
-    /// `texture_view()` / `client_dimensions()`.
+    /// Start receiving from a named Syphon server. Spawns a dedicated receive
+    /// thread (`syphon-recv-{name}`) that owns the `SyphonMetalClient`, polls
+    /// `newFrameImage`, performs the `getBytes` CPU readback off the render
+    /// thread, and publishes RGBA into `frame_data`. Returns a client index used
+    /// by `texture_view()` / `client_dimensions()`.
     pub fn start_receive(&mut self, server_name: &str, device: &wgpu::Device) -> Option<usize> {
         if !self.available {
             log::warn!("Cannot receive Syphon: framework not available");
             return None;
         }
-        if self.device.is_none() {
-            self.device = Some(device.clone());
-        }
 
+        // The description must be resolved here (render thread): SyphonServerDirectory
+        // observes distributed notifications on the render-thread run loop.
         let desc = self
             .descriptions
             .iter()
@@ -209,7 +336,7 @@ impl SyphonManager {
         let client: Retained<SyphonMetalClient> = unsafe {
             let alloc = SyphonMetalClient::alloc();
             let nil_opts: *const NSDictionary<NSString, AnyObject> = std::ptr::null();
-            // newFrameHandler: nil — we poll in update() instead of using the block.
+            // newFrameHandler: nil — we poll newFrameImage on the receive thread.
             let handler: *const AnyObject = std::ptr::null();
             msg_send![
                 alloc,
@@ -224,11 +351,50 @@ impl SyphonManager {
         let (width, height) = (1920u32, 1080u32);
         let (texture, view) = make_texture(device, server_name, width, height);
 
-        let idx = self.clients.len();
-        self.clients.push(SyphonClient {
+        let frame_data: Arc<Mutex<Option<SyphonFrame>>> = Arc::new(Mutex::new(None));
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let connected = Arc::new(AtomicBool::new(false));
+
+        // Move the !Send Metal client onto the receive thread via a raw-pointer
+        // ownership transfer, mirroring the NDI receiver's handle hand-off.
+        let client_ptr = Retained::into_raw(client) as usize;
+        let frame_clone = Arc::clone(&frame_data);
+        let stop_clone = Arc::clone(&stop_flag);
+        let connected_clone = Arc::clone(&connected);
+        let name_log = server_name.to_string();
+
+        let thread = std::thread::Builder::new()
+            .name(format!("syphon-recv-{}", server_name))
+            .spawn(move || {
+                let client: Retained<SyphonMetalClient> =
+                    match unsafe { Retained::from_raw(client_ptr as *mut SyphonMetalClient) } {
+                        Some(c) => c,
+                        None => {
+                            log::error!("Syphon '{}': null client on receive thread", name_log);
+                            return;
+                        }
+                    };
+                syphon_receive_loop(
+                    &client,
+                    &frame_clone,
+                    &stop_clone,
+                    &connected_clone,
+                    &name_log,
+                );
+                unsafe {
+                    let _: () = msg_send![&client, stop];
+                }
+                log::info!("Syphon '{}': receive thread stopping", name_log);
+            })
+            .ok();
+
+        let idx = self.receivers.len();
+        self.receivers.push(SyphonReceiver {
             server_name: server_name.to_string(),
-            client,
-            stop_flag: Arc::new(AtomicBool::new(false)),
+            frame_data,
+            stop_flag,
+            connected,
+            thread,
             width,
             height,
         });
@@ -237,56 +403,37 @@ impl SyphonManager {
         Some(idx)
     }
 
-    /// Pull the newest frame from each client and upload it to its wgpu texture.
-    /// Runs on the render thread (callers already hold `&mut self`).
-    pub fn update(&mut self, queue: &wgpu::Queue) {
-        for i in 0..self.clients.len() {
-            if self.clients[i].stop_flag.load(Ordering::Relaxed) {
-                continue;
-            }
-            // Latest completed frame, or None if nothing new.
-            let tex: Option<Retained<ProtocolObject<dyn MTLTexture>>> =
-                unsafe { msg_send![&self.clients[i].client, newFrameImage] };
-            let Some(tex) = tex else { continue };
-
-            let w = tex.width() as u32;
-            let h = tex.height() as u32;
+    /// Pull the newest frame from each receive thread and upload it to its wgpu
+    /// texture. Render-thread, upload-only: non-blocking `try_lock` + `take` +
+    /// `write_texture`, recreating the texture when the server's frame size changes.
+    pub fn update(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
+        for i in 0..self.receivers.len() {
+            let new_frame = {
+                if let Ok(mut guard) = self.receivers[i].frame_data.try_lock() {
+                    guard.take()
+                } else {
+                    None
+                }
+            };
+            let Some(frame) = new_frame else { continue };
+            let (w, h) = (frame.width, frame.height);
             if w == 0 || h == 0 {
                 continue;
             }
 
-            // Resize the wgpu texture if the server's frame size changed.
-            if w != self.clients[i].width || h != self.clients[i].height {
-                if let Some(dev) = self.device.clone() {
-                    let name = self.clients[i].server_name.clone();
-                    let (t, v) = make_texture(&dev, &name, w, h);
-                    self.textures[i] = (t, v);
-                    self.clients[i].width = w;
-                    self.clients[i].height = h;
-                }
+            // Recreate the wgpu texture if the server's frame size changed.
+            if w != self.receivers[i].width || h != self.receivers[i].height {
+                let name = self.receivers[i].server_name.clone();
+                let (t, v) = make_texture(device, &name, w, h);
+                self.textures[i] = (t, v);
+                self.receivers[i].width = w;
+                self.receivers[i].height = h;
             }
 
-            // CPU readback from the IOSurface-backed Metal texture.
-            // NOTE: requires the source texture to be Shared/Managed storage
-            // (Syphon's surface textures are Shared on Apple silicon).
-            let mut buf = vec![0u8; (w * h * 4) as usize];
-            let region = MTLRegion {
-                origin: MTLOrigin { x: 0, y: 0, z: 0 },
-                size: MTLSize {
-                    width: w as usize,
-                    height: h as usize,
-                    depth: 1,
-                },
-            };
-            unsafe {
-                tex.getBytes_bytesPerRow_fromRegion_mipmapLevel(
-                    std::ptr::NonNull::new(buf.as_mut_ptr() as *mut std::ffi::c_void).unwrap(),
-                    (w * 4) as usize,
-                    region,
-                    0,
-                );
+            let expected = (w * h * 4) as usize;
+            if frame.data.len() < expected {
+                continue;
             }
-
             queue.write_texture(
                 wgpu::TexelCopyTextureInfo {
                     texture: &self.textures[i].0,
@@ -294,7 +441,7 @@ impl SyphonManager {
                     origin: wgpu::Origin3d::ZERO,
                     aspect: wgpu::TextureAspect::All,
                 },
-                &buf,
+                &frame.data[..expected],
                 wgpu::TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(w * 4),
@@ -314,23 +461,336 @@ impl SyphonManager {
     }
 
     pub fn client_dimensions(&self, idx: usize) -> Option<(u32, u32)> {
-        self.clients.get(idx).map(|c| (c.width, c.height))
+        self.receivers.get(idx).map(|c| (c.width, c.height))
     }
 
-    /// Publishing from varda is out of scope here (varda is the client).
-    pub fn publish_frame(&mut self, _rgba: &[u8], _width: u32, _height: u32) {}
+    /// Whether the receive thread for `idx` is currently getting frames.
+    pub fn is_connected(&self, idx: usize) -> bool {
+        self.receivers
+            .get(idx)
+            .map(|r| r.connected.load(Ordering::SeqCst))
+            .unwrap_or(false)
+    }
+
+    /// Publish a composited frame to a Syphon server, GPU-side (zero-copy).
+    ///
+    /// Render-thread. Unlike the old CPU path, this takes no readback bytes: it
+    /// extracts wgpu's `MTLDevice` (`as_hal`), keeps a ring of BGRA `MTLTexture`s
+    /// imported into wgpu, runs the RGBA→BGRA conversion as a GPU blit into a
+    /// ring slot, and hands that slot's native texture to `SyphonMetalServer`.
+    /// This removes the pipeline-stalling readback and the CPU swizzle.
+    ///
+    /// `src_view` is the output's rendered texture view (e.g. `h.texture_view`).
+    /// Synchronization: a slot is published only after its blit submission
+    /// completes (`on_submitted_work_done` → `write_done`), so Syphon always
+    /// reads a fully-rendered texture; the ring depth covers Syphon's in-flight
+    /// read before a slot is reused.
+    pub fn publish_frame_gpu(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        server_name: &str,
+        src_view: &wgpu::TextureView,
+        width: u32,
+        height: u32,
+    ) {
+        if !self.available || width == 0 || height == 0 {
+            return;
+        }
+
+        // 1. wgpu's MTLDevice — unify so the imported textures, the server, and
+        //    the publish queue all live on one device.
+        if self.wgpu_metal_device.is_none() {
+            let dev =
+                unsafe { device.as_hal::<wgpu::hal::api::Metal>() }.map(|d| d.raw_device().clone());
+            match dev {
+                Some(d) => self.wgpu_metal_device = Some(d),
+                None => {
+                    log::error!("Syphon publish: device.as_hal::<Metal> returned None");
+                    return;
+                }
+            }
+        }
+        let mtl_dev = self.wgpu_metal_device.as_ref().unwrap().clone();
+
+        // 2. Publish command queue on wgpu's device (wgpu's own queue handle is
+        //    private in wgpu-hal, so the publish runs on a separate queue).
+        if self.publish_queue.is_none() {
+            self.publish_queue = mtl_dev.newCommandQueue();
+            if self.publish_queue.is_none() {
+                log::error!("Syphon publish: newCommandQueue returned nil");
+                return;
+            }
+        }
+
+        // 3. RGBA→BGRA conversion pipeline (GPU; replaces the old CPU swizzle).
+        if self.convert_pipeline.is_none() {
+            match crate::renderer::blit::BlitPipeline::new(
+                device,
+                wgpu::TextureFormat::Bgra8UnormSrgb,
+            ) {
+                Ok(p) => self.convert_pipeline = Some(p),
+                Err(e) => {
+                    log::error!("Syphon publish: failed to build convert pipeline: {e}");
+                    return;
+                }
+            }
+        }
+
+        // 4. Server + slot ring (recreate on first use / size change).
+        let need_new = match self.servers.get(server_name) {
+            None => true,
+            Some(h) => h.width != width || h.height != height,
+        };
+        if need_new {
+            let name = NSString::from_str(server_name);
+            let server: Option<Retained<SyphonMetalServer>> = unsafe {
+                let alloc = SyphonMetalServer::alloc();
+                let nil_opts: *const NSDictionary<NSString, AnyObject> = std::ptr::null();
+                msg_send![alloc, initWithName: &*name, device: &*mtl_dev, options: nil_opts]
+            };
+            let Some(server) = server else {
+                log::error!("Syphon publish: failed to create server '{}'", server_name);
+                return;
+            };
+            let mut slots = Vec::with_capacity(PUBLISH_RING);
+            for _ in 0..PUBLISH_RING {
+                match Self::make_publish_slot(&mtl_dev, device, width, height) {
+                    Some(s) => slots.push(s),
+                    None => {
+                        log::error!("Syphon publish: failed to create publish texture");
+                        return;
+                    }
+                }
+            }
+            self.servers.insert(
+                server_name.to_string(),
+                SyphonServerHandle {
+                    server,
+                    width,
+                    height,
+                    slots,
+                    sched: PublishScheduler::new(PUBLISH_RING),
+                },
+            );
+            log::info!("Syphon server publishing as '{}'", server_name);
+        }
+
+        let pipeline = self.convert_pipeline.as_ref().unwrap();
+        let pub_queue = self.publish_queue.as_ref().unwrap();
+        let handle = self.servers.get_mut(server_name).unwrap();
+
+        // 5a. Publish step (before write, so a written slot is never overwritten
+        //     before it is published). Only a GPU-complete slot is published.
+        let write_done: Vec<bool> = handle
+            .slots
+            .iter()
+            .map(|s| s.write_done.load(Ordering::SeqCst))
+            .collect();
+        if let Some(p) = handle.sched.poll_publish(&write_done) {
+            if let Some(cmd_buf) = pub_queue.commandBuffer() {
+                let image_region = NSRect {
+                    origin: NSPoint { x: 0.0, y: 0.0 },
+                    size: NSSize {
+                        width: width as f64,
+                        height: height as f64,
+                    },
+                };
+                unsafe {
+                    let _: () = msg_send![
+                        &handle.server,
+                        publishFrameTexture: &*handle.slots[p].mtl,
+                        onCommandBuffer: &*cmd_buf,
+                        imageRegion: image_region,
+                        flipped: false,
+                    ];
+                }
+                cmd_buf.commit();
+            } else {
+                log::error!("Syphon publish: commandBuffer returned nil");
+            }
+        }
+
+        // 5b. Write step: render the RGBA→BGRA conversion into a free slot and
+        //     arm its completion flag so it can be published next frame.
+        if let Some(w) = handle.sched.poll_write() {
+            let bind = pipeline.create_bind_group(device, src_view);
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Syphon Convert Encoder"),
+            });
+            {
+                let mut rp = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Syphon Convert Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &handle.slots[w].view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                        depth_slice: None,
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                    multiview_mask: None,
+                });
+                pipeline.render(&mut rp, &bind);
+            }
+            let flag = handle.slots[w].write_done.clone();
+            flag.store(false, Ordering::SeqCst);
+            queue.submit(std::iter::once(encoder.finish()));
+            queue.on_submitted_work_done(move || flag.store(true, Ordering::SeqCst));
+            handle.sched.mark_written(w);
+        }
+    }
+
+    /// Create one publish texture on wgpu's `MTLDevice` and import it into wgpu
+    /// so the conversion blit can target it while Syphon reads the same native
+    /// texture (zero-copy share). `BGRA8Unorm_sRGB` matches Syphon's BGRA
+    /// convention and the sRGB encoding the old CPU path produced.
+    fn make_publish_slot(
+        mtl_dev: &Retained<ProtocolObject<dyn MTLDevice>>,
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+    ) -> Option<PublishSlot> {
+        let desc = unsafe {
+            MTLTextureDescriptor::texture2DDescriptorWithPixelFormat_width_height_mipmapped(
+                MTLPixelFormat::BGRA8Unorm_sRGB,
+                width as usize,
+                height as usize,
+                false,
+            )
+        };
+        desc.setUsage(MTLTextureUsage::ShaderRead | MTLTextureUsage::RenderTarget);
+        desc.setStorageMode(MTLStorageMode::Private);
+        let mtl = mtl_dev.newTextureWithDescriptor(&desc)?;
+
+        // Import the same MTLTexture into wgpu; keep a retained clone for Syphon.
+        let hal_texture = unsafe {
+            wgpu::hal::metal::Device::texture_from_raw(
+                mtl.clone(),
+                wgpu::TextureFormat::Bgra8UnormSrgb,
+                MTLTextureType::Type2D,
+                1,
+                1,
+                wgpu::hal::CopyExtent {
+                    width,
+                    height,
+                    depth: 1,
+                },
+            )
+        };
+        let wgpu_texture = unsafe {
+            device.create_texture_from_hal::<wgpu::hal::api::Metal>(
+                hal_texture,
+                &wgpu::TextureDescriptor {
+                    label: Some("Syphon Publish Texture"),
+                    size: wgpu::Extent3d {
+                        width,
+                        height,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                        | wgpu::TextureUsages::TEXTURE_BINDING,
+                    view_formats: &[],
+                },
+            )
+        };
+        let view = wgpu_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Some(PublishSlot {
+            mtl,
+            _wgpu_texture: wgpu_texture,
+            view,
+            write_done: Arc::new(AtomicBool::new(true)),
+        })
+    }
 
     pub fn stop_receive(&mut self, idx: usize) {
-        if let Some(c) = self.clients.get_mut(idx) {
-            c.stop_flag.store(true, Ordering::SeqCst);
-            unsafe {
-                let _: () = msg_send![&c.client, stop];
+        if let Some(r) = self.receivers.get_mut(idx) {
+            r.stop_flag.store(true, Ordering::SeqCst);
+            if let Some(t) = r.thread.take() {
+                let _ = t.join();
             }
         }
     }
 
     fn check_framework() -> bool {
         framework_loaded()
+    }
+}
+
+/// Receive loop body, run on a dedicated `syphon-recv-*` thread. Polls the
+/// client for new frames, performs the CPU readback, and swaps RGBA into
+/// `frame_data`. Tracks a `connected` flag: a producer that stops publishing is
+/// marked disconnected after ~2s of nil frames.
+fn syphon_receive_loop(
+    client: &Retained<SyphonMetalClient>,
+    frame_data: &Arc<Mutex<Option<SyphonFrame>>>,
+    stop_flag: &Arc<AtomicBool>,
+    connected: &Arc<AtomicBool>,
+    name: &str,
+) {
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(8);
+    // ~Nil polls before declaring the producer gone (~2s at 8ms).
+    const DISCONNECT_AFTER: u32 = 250;
+    let mut nil_count: u32 = 0;
+
+    while !stop_flag.load(Ordering::SeqCst) {
+        let tex: Option<Retained<ProtocolObject<dyn MTLTexture>>> =
+            unsafe { msg_send![client, newFrameImage] };
+        let Some(tex) = tex else {
+            nil_count = nil_count.saturating_add(1);
+            if nil_count == DISCONNECT_AFTER {
+                connected.store(false, Ordering::SeqCst);
+                log::debug!("Syphon '{}': no frames (~2s), marked disconnected", name);
+            }
+            std::thread::sleep(POLL_INTERVAL);
+            continue;
+        };
+        nil_count = 0;
+
+        let w = tex.width() as u32;
+        let h = tex.height() as u32;
+        if w == 0 || h == 0 {
+            std::thread::sleep(POLL_INTERVAL);
+            continue;
+        }
+
+        // CPU readback from the IOSurface-backed Metal texture (off the render
+        // thread). Syphon surface textures are Shared on Apple silicon.
+        let mut buf = vec![0u8; (w * h * 4) as usize];
+        let region = MTLRegion {
+            origin: MTLOrigin { x: 0, y: 0, z: 0 },
+            size: MTLSize {
+                width: w as usize,
+                height: h as usize,
+                depth: 1,
+            },
+        };
+        unsafe {
+            tex.getBytes_bytesPerRow_fromRegion_mipmapLevel(
+                std::ptr::NonNull::new(buf.as_mut_ptr() as *mut std::ffi::c_void).unwrap(),
+                (w * 4) as usize,
+                region,
+                0,
+            );
+        }
+
+        connected.store(true, Ordering::SeqCst);
+        if let Ok(mut guard) = frame_data.lock() {
+            *guard = Some(SyphonFrame {
+                data: buf,
+                width: w,
+                height: h,
+            });
+        }
+        std::thread::sleep(POLL_INTERVAL);
     }
 }
 
@@ -405,10 +865,15 @@ fn make_texture(
 
 impl Drop for SyphonManager {
     fn drop(&mut self) {
-        for c in &mut self.clients {
-            c.stop_flag.store(true, Ordering::SeqCst);
+        for r in &mut self.receivers {
+            r.stop_flag.store(true, Ordering::SeqCst);
+            if let Some(t) = r.thread.take() {
+                let _ = t.join();
+            }
+        }
+        for h in self.servers.values() {
             unsafe {
-                let _: () = msg_send![&c.client, stop];
+                let _: () = msg_send![&h.server, stop];
             }
         }
     }
@@ -464,5 +929,60 @@ mod tests {
         let mut mgr = SyphonManager::new_disabled();
         mgr.discover();
         assert!(mgr.sources().is_empty());
+    }
+
+    #[test]
+    fn syphon_manager_is_connected_out_of_bounds() {
+        let mgr = SyphonManager::new();
+        assert!(!mgr.is_connected(0));
+        assert!(!mgr.is_connected(999));
+    }
+
+    #[test]
+    fn syphon_manager_disabled_has_no_servers() {
+        // A disabled manager must never create publishers.
+        let mgr = SyphonManager::new_disabled();
+        assert!(!mgr.is_available());
+        assert!(mgr.servers.is_empty());
+    }
+
+    #[test]
+    fn publish_scheduler_write_publish_cycle() {
+        let mut s = PublishScheduler::new(PUBLISH_RING);
+        // Nothing pending → nothing to publish; first write takes slot 0.
+        assert_eq!(s.poll_publish(&[false, false, false]), None);
+        assert_eq!(s.poll_write(), Some(0));
+        s.mark_written(0);
+        // Slot 0's blit not finished → no publish, and writes are blocked.
+        assert_eq!(s.poll_publish(&[false, false, false]), None);
+        assert_eq!(s.poll_write(), None);
+        // Blit done → publish 0, then the next write advances to slot 1.
+        assert_eq!(s.poll_publish(&[true, false, false]), Some(0));
+        assert_eq!(s.poll_write(), Some(1));
+        s.mark_written(1);
+        assert_eq!(s.poll_publish(&[false, true, false]), Some(1));
+        assert_eq!(s.poll_write(), Some(2));
+        s.mark_written(2);
+        assert_eq!(s.poll_publish(&[false, false, true]), Some(2));
+        // Cursor wraps back to slot 0.
+        assert_eq!(s.poll_write(), Some(0));
+    }
+
+    #[test]
+    fn publish_scheduler_no_publish_without_pending() {
+        let mut s = PublishScheduler::new(PUBLISH_RING);
+        assert_eq!(s.poll_publish(&[true, true, true]), None);
+    }
+
+    #[test]
+    fn publish_scheduler_backpressure_blocks_write_until_published() {
+        let mut s = PublishScheduler::new(2);
+        assert_eq!(s.poll_write(), Some(0));
+        s.mark_written(0);
+        // Unpublished pending slot → writes blocked (frame dropped, not clobbered).
+        assert_eq!(s.poll_write(), None);
+        assert_eq!(s.poll_write(), None);
+        assert_eq!(s.poll_publish(&[true, false]), Some(0));
+        assert_eq!(s.poll_write(), Some(1));
     }
 }

--- a/src/internal/syphon/mod.rs
+++ b/src/internal/syphon/mod.rs
@@ -1,42 +1,100 @@
 //! Syphon — macOS inter-app GPU texture sharing.
 //!
-//! Syphon allows applications to share rendered frames in real-time via IOSurface.
-//! Input follows the CameraManager pattern: receive thread → Arc<Mutex<>> → GPU upload.
-//! Output publishes frames from HeadlessOutput readback.
+//! varda is the *client*: it discovers Syphon servers and receives their frames
+//! via IOSurface. The receive is a CPU readback — `[SyphonMetalClient newFrameImage]`
+//! returns an IOSurface-backed `MTLTexture`, we `getBytes` it into a buffer, and
+//! `update()` uploads that to the wgpu texture. This needs no wgpu↔Metal device
+//! bridge and reuses varda's existing texture plumbing; on Apple-silicon unified
+//! memory the readback is a cheap same-memory copy. A zero-copy path (wrap the
+//! IOSurface `MTLTexture` directly as a `wgpu::Texture`) is a possible follow-on.
 //!
-//! macOS only. Requires Syphon.framework installed on the system.
+//! macOS only. Syphon.framework is loaded at runtime via `dlopen` (see
+//! `framework_loaded`), not linked — a Mac without Syphon installed still builds
+//! and runs, with Syphon features disabled.
 
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
+    Arc, OnceLock,
 };
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, ProtocolObject};
+use objc2::{extern_class, msg_send, AnyThread, ClassType};
+use objc2_foundation::{NSArray, NSDictionary, NSString};
+use objc2_metal::{
+    MTLCreateSystemDefaultDevice, MTLDevice, MTLOrigin, MTLRegion, MTLSize, MTLTexture,
+};
+
+// ---------------------------------------------------------------------------
+// Syphon.framework FFI. These classes are vended by Syphon.framework (loaded at
+// runtime via dlopen), declared here as opaque NSObject subclasses.
+//
+// SyphonServerDirectory.h:
+//   + (SyphonServerDirectory *)sharedDirectory;
+//   - (NSArray<NSDictionary *> *)serversMatchingName:(NSString *)name
+//                                              appName:(NSString *)appName;
+// SyphonMetalClient.h:
+//   - initWithServerDescription:(NSDictionary *)desc device:(id<MTLDevice>)dev
+//                       options:(NSDictionary *)opts
+//               newFrameHandler:(void (^)(SyphonMetalClient *))handler;
+//   - (id<MTLTexture>)newFrameImage;
+//   - (void)stop;
+// ---------------------------------------------------------------------------
+extern_class!(
+    #[unsafe(super(objc2::runtime::NSObject))]
+    #[name = "SyphonServerDirectory"]
+    pub struct SyphonServerDirectory;
+);
+
+extern_class!(
+    #[unsafe(super(objc2::runtime::NSObject))]
+    #[name = "SyphonMetalClient"]
+    pub struct SyphonMetalClient;
+);
+
+// Syphon server-description dictionary keys. The framework exports these as
+// extern NSString constants; we reconstruct them from their documented values
+// to avoid an extern-static binding.
+const KEY_NAME: &str = "SyphonServerDescriptionNameKey";
+const KEY_APP: &str = "SyphonServerDescriptionAppNameKey";
 
 /// Discovered Syphon server.
 #[derive(Debug, Clone)]
 pub struct SyphonSource {
-    /// Server name
+    /// Server name (matches the publisher's server name).
     pub name: String,
-    /// Application name publishing the server
+    /// Application name publishing the server.
     pub app_name: String,
 }
 
-/// Manages Syphon server discovery, client connections, and server publishing.
+/// Manages Syphon server discovery and client connections.
 pub struct SyphonManager {
     available: bool,
     sources: Vec<SyphonSource>,
+    /// Server-description dicts kept alongside `sources` by name, needed to init
+    /// a `SyphonMetalClient`.
+    descriptions: Vec<(String, Retained<NSDictionary<NSString, AnyObject>>)>,
     clients: Vec<SyphonClient>,
     textures: Vec<(wgpu::Texture, wgpu::TextureView)>,
+    /// Our own Metal device for the clients (one GPU on M-series). Lazily created.
+    metal_device: Option<Retained<ProtocolObject<dyn MTLDevice>>>,
+    /// wgpu device clone, captured at first `start_receive`, so `update()` can
+    /// (re)create textures when a server's frame size becomes known/changes.
+    device: Option<wgpu::Device>,
 }
 
 struct SyphonClient {
     #[allow(dead_code)]
     server_name: String,
-    frame_data: Arc<Mutex<Option<Vec<u8>>>>,
+    client: Retained<SyphonMetalClient>,
     stop_flag: Arc<AtomicBool>,
-    _thread: Option<std::thread::JoinHandle<()>>,
     width: u32,
     height: u32,
 }
+
+// Single-threaded ownership: the manager lives on (and is only touched from)
+// varda's render thread. Metal objects aren't Sync but are never shared.
+unsafe impl Send for SyphonManager {}
 
 impl Default for SyphonManager {
     fn default() -> Self {
@@ -55,19 +113,19 @@ impl SyphonManager {
         Self {
             available,
             sources: Vec::new(),
+            descriptions: Vec::new(),
             clients: Vec::new(),
             textures: Vec::new(),
+            metal_device: None,
+            device: None,
         }
     }
 
     /// Create a disabled Syphon manager (CLI `--no-syphon` flag).
     pub fn new_disabled() -> Self {
-        Self {
-            available: false,
-            sources: Vec::new(),
-            clients: Vec::new(),
-            textures: Vec::new(),
-        }
+        let mut m = Self::new();
+        m.available = false;
+        m
     }
 
     pub fn is_available(&self) -> bool {
@@ -82,85 +140,172 @@ impl SyphonManager {
         self.sources.iter().map(|s| s.name.clone()).collect()
     }
 
-    /// Scan for available Syphon servers.
+    fn metal_device(&mut self) -> Option<&Retained<ProtocolObject<dyn MTLDevice>>> {
+        if self.metal_device.is_none() {
+            self.metal_device = MTLCreateSystemDefaultDevice();
+            if self.metal_device.is_none() {
+                log::error!("Syphon: MTLCreateSystemDefaultDevice returned nil");
+            }
+        }
+        self.metal_device.as_ref()
+    }
+
+    /// Scan for available Syphon servers via SyphonServerDirectory.
     pub fn discover(&mut self) {
         if !self.available {
             return;
         }
-        log::debug!("Syphon discover: scanning...");
         self.sources.clear();
-        // TODO: Use SyphonServerDirectory to enumerate servers
+        self.descriptions.clear();
+
+        unsafe {
+            let dir: Retained<SyphonServerDirectory> =
+                msg_send![SyphonServerDirectory::class(), sharedDirectory];
+            // serversMatchingName:nil appName:nil → all servers.
+            let nil_str: *const NSString = std::ptr::null();
+            let servers: Retained<NSArray<NSDictionary<NSString, AnyObject>>> =
+                msg_send![&dir, serversMatchingName: nil_str, appName: nil_str];
+
+            let count: usize = msg_send![&servers, count];
+            let name_key = NSString::from_str(KEY_NAME);
+            let app_key = NSString::from_str(KEY_APP);
+            for i in 0..count {
+                let desc: Retained<NSDictionary<NSString, AnyObject>> =
+                    msg_send![&servers, objectAtIndex: i];
+                let name = nsstring_value(&desc, &name_key).unwrap_or_default();
+                let app_name = nsstring_value(&desc, &app_key).unwrap_or_default();
+                self.sources.push(SyphonSource {
+                    name: name.clone(),
+                    app_name,
+                });
+                self.descriptions.push((name, desc));
+            }
+        }
+        log::debug!("Syphon discover: {} server(s)", self.sources.len());
     }
 
-    /// Start receiving from a named Syphon server.
+    /// Start receiving from a named Syphon server. Returns a client index used by
+    /// `texture_view()` / `client_dimensions()`.
     pub fn start_receive(&mut self, server_name: &str, device: &wgpu::Device) -> Option<usize> {
         if !self.available {
             log::warn!("Cannot receive Syphon: framework not available");
             return None;
         }
-        let frame_data: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        let (width, height) = (1920, 1080);
+        if self.device.is_none() {
+            self.device = Some(device.clone());
+        }
 
-        let texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some(&format!("Syphon Client: {}", server_name)),
-            size: wgpu::Extent3d {
-                width,
-                height,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8UnormSrgb,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-            view_formats: &[],
-        });
-        let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let desc = self
+            .descriptions
+            .iter()
+            .find(|(n, _)| n == server_name)
+            .map(|(_, d)| d.clone());
+        let Some(desc) = desc else {
+            log::warn!("Syphon: no discovered server named '{}'", server_name);
+            return None;
+        };
+
+        let metal = self.metal_device()?.clone();
+        let client: Retained<SyphonMetalClient> = unsafe {
+            let alloc = SyphonMetalClient::alloc();
+            let nil_opts: *const NSDictionary<NSString, AnyObject> = std::ptr::null();
+            // newFrameHandler: nil — we poll in update() instead of using the block.
+            let handler: *const AnyObject = std::ptr::null();
+            msg_send![
+                alloc,
+                initWithServerDescription: &*desc,
+                device: &*metal,
+                options: nil_opts,
+                newFrameHandler: handler,
+            ]
+        };
+
+        // Placeholder size; corrected on the first frame in update().
+        let (width, height) = (1920u32, 1080u32);
+        let (texture, view) = make_texture(device, server_name, width, height);
 
         let idx = self.clients.len();
         self.clients.push(SyphonClient {
             server_name: server_name.to_string(),
-            frame_data,
-            stop_flag,
-            _thread: None,
+            client,
+            stop_flag: Arc::new(AtomicBool::new(false)),
             width,
             height,
         });
-        self.textures.push((texture, texture_view));
+        self.textures.push((texture, view));
         log::info!("Syphon client connected to '{}'", server_name);
         Some(idx)
     }
 
-    /// Upload latest frames from all clients to GPU.
-    pub fn update(&self, queue: &wgpu::Queue) {
-        for (i, client) in self.clients.iter().enumerate() {
-            if let Ok(mut guard) = client.frame_data.try_lock() {
-                if let Some(frame) = guard.take() {
-                    let expected = (client.width * client.height * 4) as usize;
-                    if frame.len() >= expected {
-                        queue.write_texture(
-                            wgpu::TexelCopyTextureInfo {
-                                texture: &self.textures[i].0,
-                                mip_level: 0,
-                                origin: wgpu::Origin3d::ZERO,
-                                aspect: wgpu::TextureAspect::All,
-                            },
-                            &frame[..expected],
-                            wgpu::TexelCopyBufferLayout {
-                                offset: 0,
-                                bytes_per_row: Some(client.width * 4),
-                                rows_per_image: Some(client.height),
-                            },
-                            wgpu::Extent3d {
-                                width: client.width,
-                                height: client.height,
-                                depth_or_array_layers: 1,
-                            },
-                        );
-                    }
+    /// Pull the newest frame from each client and upload it to its wgpu texture.
+    /// Runs on the render thread (callers already hold `&mut self`).
+    pub fn update(&mut self, queue: &wgpu::Queue) {
+        for i in 0..self.clients.len() {
+            if self.clients[i].stop_flag.load(Ordering::Relaxed) {
+                continue;
+            }
+            // Latest completed frame, or None if nothing new.
+            let tex: Option<Retained<ProtocolObject<dyn MTLTexture>>> =
+                unsafe { msg_send![&self.clients[i].client, newFrameImage] };
+            let Some(tex) = tex else { continue };
+
+            let w = tex.width() as u32;
+            let h = tex.height() as u32;
+            if w == 0 || h == 0 {
+                continue;
+            }
+
+            // Resize the wgpu texture if the server's frame size changed.
+            if w != self.clients[i].width || h != self.clients[i].height {
+                if let Some(dev) = self.device.clone() {
+                    let name = self.clients[i].server_name.clone();
+                    let (t, v) = make_texture(&dev, &name, w, h);
+                    self.textures[i] = (t, v);
+                    self.clients[i].width = w;
+                    self.clients[i].height = h;
                 }
             }
+
+            // CPU readback from the IOSurface-backed Metal texture.
+            // NOTE: requires the source texture to be Shared/Managed storage
+            // (Syphon's surface textures are Shared on Apple silicon).
+            let mut buf = vec![0u8; (w * h * 4) as usize];
+            let region = MTLRegion {
+                origin: MTLOrigin { x: 0, y: 0, z: 0 },
+                size: MTLSize {
+                    width: w as usize,
+                    height: h as usize,
+                    depth: 1,
+                },
+            };
+            unsafe {
+                tex.getBytes_bytesPerRow_fromRegion_mipmapLevel(
+                    std::ptr::NonNull::new(buf.as_mut_ptr() as *mut std::ffi::c_void).unwrap(),
+                    (w * 4) as usize,
+                    region,
+                    0,
+                );
+            }
+
+            queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &self.textures[i].0,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &buf,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(w * 4),
+                    rows_per_image: Some(h),
+                },
+                wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+            );
         }
     }
 
@@ -172,43 +317,152 @@ impl SyphonManager {
         self.clients.get(idx).map(|c| (c.width, c.height))
     }
 
-    /// Publish a frame via Syphon server (for HeadlessOutput with SyphonServer target).
-    pub fn publish_frame(&mut self, rgba: &[u8], width: u32, height: u32) {
-        if !self.available {
-            return;
-        }
-        let _ = (rgba, width, height); // TODO: Publish via Syphon.framework
-    }
+    /// Publishing from varda is out of scope here (varda is the client).
+    pub fn publish_frame(&mut self, _rgba: &[u8], _width: u32, _height: u32) {}
 
     pub fn stop_receive(&mut self, idx: usize) {
         if let Some(c) = self.clients.get_mut(idx) {
             c.stop_flag.store(true, Ordering::SeqCst);
-            if let Some(t) = c._thread.take() {
-                let _ = t.join();
+            unsafe {
+                let _: () = msg_send![&c.client, stop];
             }
         }
     }
 
     fn check_framework() -> bool {
-        // Check standard Syphon.framework locations
-        let paths = [
-            "/Library/Frameworks/Syphon.framework",
-            &format!(
-                "{}/Library/Frameworks/Syphon.framework",
+        framework_loaded()
+    }
+}
+
+/// dlopen Syphon.framework once and keep it loaded for the process lifetime.
+///
+/// We load at runtime (via libloading, already a varda dep) rather than linking
+/// the framework, so a Mac *without* Syphon installed still builds and runs —
+/// `available` simply stays false and every Syphon call is guarded. Once loaded,
+/// the Obj-C runtime can resolve `SyphonServerDirectory` / `SyphonMetalClient`
+/// by name (`objc_getClass`), which is all `extern_class!` + `msg_send!` need.
+fn framework_loaded() -> bool {
+    static SYPHON_LIB: OnceLock<Option<libloading::Library>> = OnceLock::new();
+    let lib = SYPHON_LIB.get_or_init(|| {
+        let candidates = [
+            "/Library/Frameworks/Syphon.framework/Syphon".to_string(),
+            format!(
+                "{}/Library/Frameworks/Syphon.framework/Syphon",
                 std::env::var("HOME").unwrap_or_default()
             ),
         ];
-        paths.iter().any(|p| std::path::Path::new(p).exists())
+        for p in candidates {
+            if std::path::Path::new(&p).exists() {
+                match unsafe { libloading::Library::new(&p) } {
+                    Ok(l) => return Some(l),
+                    Err(e) => log::warn!("Syphon: dlopen of {p} failed: {e}"),
+                }
+            }
+        }
+        None
+    });
+    lib.is_some()
+}
+
+/// Read an NSString value out of a server-description dictionary.
+fn nsstring_value(dict: &NSDictionary<NSString, AnyObject>, key: &NSString) -> Option<String> {
+    unsafe {
+        let val: *mut AnyObject = msg_send![dict, objectForKey: key];
+        if val.is_null() {
+            return None;
+        }
+        let s: &NSString = &*(val as *const NSString);
+        Some(s.to_string())
     }
+}
+
+/// Allocate the RGBA wgpu texture + view a Syphon client uploads into.
+fn make_texture(
+    device: &wgpu::Device,
+    server_name: &str,
+    width: u32,
+    height: u32,
+) -> (wgpu::Texture, wgpu::TextureView) {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some(&format!("Syphon Client: {}", server_name)),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        // Syphon getBytes hands back BGRA byte order (servers publish BGRA8Unorm);
+        // Bgra8UnormSrgb matches the existing client expectation.
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    (texture, view)
 }
 
 impl Drop for SyphonManager {
     fn drop(&mut self) {
         for c in &mut self.clients {
             c.stop_flag.store(true, Ordering::SeqCst);
-            if let Some(t) = c._thread.take() {
-                let _ = t.join();
+            unsafe {
+                let _: () = msg_send![&c.client, stop];
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These exercise the host-independent paths only: a fresh manager holds no
+    // clients/sources, so none of these touch Syphon.framework or Metal. They
+    // pass whether or not Syphon is installed on the test machine.
+
+    #[test]
+    fn syphon_manager_new_no_crash() {
+        // new() probes for Syphon.framework; on machines without it, `available`
+        // is simply false. Just verify construction and the query don't panic.
+        let mgr = SyphonManager::new();
+        let _ = mgr.is_available();
+    }
+
+    #[test]
+    fn syphon_manager_disabled_is_unavailable() {
+        let mgr = SyphonManager::new_disabled();
+        assert!(!mgr.is_available());
+    }
+
+    #[test]
+    fn syphon_manager_sources_empty() {
+        let mgr = SyphonManager::new();
+        assert!(mgr.sources().is_empty());
+        assert!(mgr.discovered_sources().is_empty());
+    }
+
+    #[test]
+    fn syphon_manager_texture_view_out_of_bounds() {
+        let mgr = SyphonManager::new();
+        assert!(mgr.texture_view(0).is_none());
+        assert!(mgr.texture_view(999).is_none());
+    }
+
+    #[test]
+    fn syphon_manager_client_dimensions_out_of_bounds() {
+        let mgr = SyphonManager::new();
+        assert!(mgr.client_dimensions(0).is_none());
+        assert!(mgr.client_dimensions(999).is_none());
+    }
+
+    #[test]
+    fn syphon_manager_discover_noop_when_unavailable() {
+        // discover() early-returns when the framework is absent; on a machine
+        // with Syphon it may populate sources, but must never panic either way.
+        let mut mgr = SyphonManager::new_disabled();
+        mgr.discover();
+        assert!(mgr.sources().is_empty());
     }
 }

--- a/src/usecases/ui/panels/outputs.rs
+++ b/src/usecases/ui/panels/outputs.rs
@@ -486,6 +486,9 @@ fn render_stream_config(
                 .selected_text(egui::RichText::new(current_proto).small())
                 .width(80.0)
                 .show_ui(ui, |ui| {
+                    // `mut` is required on macOS for the Syphon push below; on other
+                    // platforms that push is compiled out, leaving the binding unused-mut.
+                    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
                     let mut protocols: Vec<(&str, OutputTarget)> = vec![
                         (
                             "SRT",

--- a/src/usecases/ui/panels/outputs.rs
+++ b/src/usecases/ui/panels/outputs.rs
@@ -322,7 +322,7 @@ fn render_headless_controls(
         }
     }
 
-    // Unified stream config (SRT, HLS, DASH, NDI)
+    // Unified stream config (SRT, HLS, DASH, RTMP, NDI, Syphon)
     let is_stream = matches!(
         output.target,
         OutputTarget::SrtStream { .. }
@@ -330,6 +330,7 @@ fn render_headless_controls(
             | OutputTarget::DashStream { .. }
             | OutputTarget::RtmpStream { .. }
             | OutputTarget::NdiSend { .. }
+            | OutputTarget::SyphonServer { .. }
     );
     if is_stream {
         render_stream_config(ui, idx, output, actions);
@@ -457,7 +458,7 @@ fn render_headless_controls(
     render_edge_blend_controls(ui, idx, output, actions);
 }
 
-/// Unified stream output config with protocol dropdown (SRT, HLS, DASH, NDI).
+/// Unified stream output config with protocol dropdown (SRT, HLS, DASH, RTMP, NDI, Syphon).
 fn render_stream_config(
     ui: &mut egui::Ui,
     idx: usize,
@@ -473,6 +474,7 @@ fn render_stream_config(
         OutputTarget::DashStream { .. } => "DASH",
         OutputTarget::RtmpStream { .. } => "RTMP",
         OutputTarget::NdiSend { .. } => "NDI",
+        OutputTarget::SyphonServer { .. } => "Syphon",
         _ => return,
     };
 
@@ -484,7 +486,7 @@ fn render_stream_config(
                 .selected_text(egui::RichText::new(current_proto).small())
                 .width(80.0)
                 .show_ui(ui, |ui| {
-                    for (label, default_target) in &[
+                    let mut protocols: Vec<(&str, OutputTarget)> = vec![
                         (
                             "SRT",
                             OutputTarget::SrtStream {
@@ -524,7 +526,15 @@ fn render_stream_config(
                                 sender_name: "Varda NDI".to_string(),
                             },
                         ),
-                    ] {
+                    ];
+                    #[cfg(target_os = "macos")]
+                    protocols.push((
+                        "Syphon",
+                        OutputTarget::SyphonServer {
+                            server_name: "Varda".to_string(),
+                        },
+                    ));
+                    for (label, default_target) in &protocols {
                         if ui
                             .selectable_label(current_proto == *label, *label)
                             .clicked()
@@ -746,6 +756,31 @@ fn render_stream_config(
                             idx,
                             target: OutputTarget::NdiSend {
                                 sender_name: current_name,
+                            },
+                        });
+                    }
+                }
+            });
+        }
+        OutputTarget::SyphonServer { ref server_name } if !output.is_active => {
+            ui.horizontal(|ui| {
+                ui.label(egui::RichText::new("Name:").small());
+                let name_id = egui::Id::new(format!("syphon_name_{}", idx));
+                let mut current_name: String = ui
+                    .data(|d| d.get_temp(name_id))
+                    .unwrap_or_else(|| server_name.clone());
+                let response = ui.add(
+                    egui::TextEdit::singleline(&mut current_name)
+                        .desired_width(140.0)
+                        .font(egui::TextStyle::Small),
+                );
+                if response.lost_focus() || response.changed() {
+                    ui.data_mut(|d| d.insert_temp(name_id, current_name.clone()));
+                    if response.lost_focus() {
+                        actions.output_actions.push(OutputAction::SetTarget {
+                            idx,
+                            target: OutputTarget::SyphonServer {
+                                server_name: current_name,
                             },
                         });
                     }

--- a/tests/command_roundtrip.rs
+++ b/tests/command_roundtrip.rs
@@ -249,6 +249,43 @@ fn headless_output_create_and_stop() {
     let _state = app.build_engine_state();
 }
 
+#[test]
+fn headless_output_syphon_create_and_start() {
+    let Some(mut app) = headless_app() else {
+        return;
+    };
+    // Create a headless output targeting a Syphon server — the same path the
+    // API takes for `POST /api/outputs/headless` with a SyphonServer target.
+    // This proves the API is co-equal with the UI's Syphon protocol dropdown.
+    let r = send_cmd(
+        &mut app,
+        EngineCommand::CreateHeadlessOutput {
+            target: varda::renderer::context::OutputTarget::SyphonServer {
+                server_name: "Test Syphon".into(),
+            },
+        },
+    );
+    assert!(matches!(r, CommandResult::Ok));
+
+    // A fresh headless app starts with no outputs, so the created Syphon output
+    // is at index 0. Starting it activates the publisher on macOS; on other
+    // platforms it must be rejected with Unavailable, mirroring the Syphon
+    // receive deck path (cmd_add_syphon_deck).
+    let r = send_cmd(&mut app, EngineCommand::StartOutput { idx: 0 });
+    #[cfg(target_os = "macos")]
+    assert!(matches!(r, CommandResult::Ok));
+    #[cfg(not(target_os = "macos"))]
+    assert!(matches!(
+        r,
+        CommandResult::Err {
+            code: ErrorCode::Unavailable,
+            ..
+        }
+    ));
+
+    let _state = app.build_engine_state();
+}
+
 // ── Stream Library Commands ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Replace the receiver stub with a working SyphonMetalClient path: discover servers through SyphonServerDirectory, then per frame pull newFrameImage and getBytes into varda's existing wgpu upload path (CPU readback). Surrounding plumbing (new_from_syphon, ExternalSourceKind::Syphon, UI discovery) already existed.

Syphon.framework is dlopen'd at runtime via libloading, so Macs without it still build and run. Build-time additions are the macOS-gated objc2 / objc2-foundation / objc2-metal crates.