### PR TITLE
#63: add interactive mode, refresh, transparent background toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11446,6 +11446,7 @@ dependencies = [
  "image",
  "imageproc",
  "json-patch",
+ "keyboard-types",
  "libloading 0.9.0",
  "log",
  "midir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ ndarray = { version = "0.17.2", optional = true }
 servo = { version = "0.1.0", optional = true }
 url = { version = "2.5", optional = true }
 euclid = { version = "0.22", optional = true }
+keyboard-types = { version = "0.8", optional = true }
 
 # Syphon client FFI (macOS only). The syphon module is compiled unconditionally
 # on macOS; Syphon.framework itself is dlopen'd at runtime (via libloading), so
@@ -110,10 +111,11 @@ face-detection = ["dep:ort", "dep:ndarray"]
 # Servo is heavy to build but the feature is stable, so it ships in the default
 # profile. Disable with `--no-default-features` (re-add `face-detection` as needed).
 # See spec/html-source.md "Decision: html on by default".
-html = ["dep:servo", "dep:url", "dep:euclid"]
+html = ["dep:servo", "dep:url", "dep:euclid", "dep:keyboard-types"]
 test-fixtures = []
 url = ["dep:url"]
 euclid = ["dep:euclid"]
+keyboard-types = ["dep:keyboard-types"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/docs/09-streaming-and-io.md
+++ b/docs/09-streaming-and-io.md
@@ -96,6 +96,7 @@ Each output can record to a video file independently. Multiple simultaneous reco
 | H.265 | Better compression, smaller files |
 | AV1 | Best compression, slower encoding |
 | ProRes 422 | Professional edit-ready |
+| ProRes 4444 | Professional edit-ready with alpha channel |
 | HAP | VJ content re-use, GPU-native playback |
 | HAP Alpha | HAP with alpha channel |
 | HAP Q | Higher quality HAP (YCoCg compression) |
@@ -204,11 +205,25 @@ HTML decks are persisted in `scene.json` by URL and reload automatically. The so
 
 ### Rendering & performance
 
-HTML is rasterized on the **CPU** (Servo's software renderer) and uploaded to a GPU texture each frame. This keeps the feature portable across every platform and architecture, but it is heavier than the GPU-native deck types. It comfortably handles HTML/CSS/SVG, dashboards, and text overlays; heavy WebGL or full-screen Canvas animation at high resolution may not sustain 60 fps. Profile your pages with the `html_render` benchmark (see [Benchmarking](14-benchmarking.md)) if frame rate matters.
+HTML is rasterized on the **CPU** (Servo's software renderer) and uploaded to a GPU texture each frame. It is heavier than the GPU-native deck types.
+
+> **Platform support.** HTML decks are available on **Apple Silicon macOS** (arm64) and **Linux** (x86_64). They are **not** available on Intel (x86_64) macOS: Servo deck-creation hangs under Rosetta, so the macOS DMG ships HTML in the Apple Silicon slice only. It comfortably handles HTML/CSS/SVG, dashboards, and text overlays; heavy WebGL or full-screen Canvas animation at high resolution may not sustain 60 fps. Profile your pages with the `html_render` benchmark (see [Benchmarking](14-benchmarking.md)) if frame rate matters.
 
 > **Non-blocking, like the stream sources.** HTML rendering runs on a dedicated background thread (a shared Servo engine), the same way NDI/SRT/HLS/DASH/RTMP decode off the render loop. Finished frames are handed to the render thread and uploaded without blocking, so even a heavy page can't stall the 60 fps loop — it simply updates at whatever rate it can render.
 
 > **Feature flag.** HTML decks require the `html` build feature, which is **on by default**. Disable rendering for a session with `--no-html`, or build without it via `--no-default-features`.
+
+### Transparency
+
+HTML decks can keep their transparent regions transparent so the page composites over lower channels and passes through to alpha-capable outputs. Enable the **Transparent BG** toggle in the HTML deck's detail panel (off by default). With it on, anything the page doesn't paint (or paints with `alpha < 1`) stays see-through instead of being filled with black.
+
+> **Where transparency reaches.** The on-screen display is always opaque — the program is composited over black, so a transparent deck shows through to whatever is behind it in the channel stack, not through the app window. Alpha reaches **Syphon** and alpha-capable **recording** codecs (**ProRes 4444**, **HAP Alpha** — see [Recording](#recording)). **NDI** output stays opaque.
+
+> **Default background is now black.** The embedded browser's page background is transparent globally. For a deck with **Transparent BG off** (the default), the page is flattened over black, so a page that set no `html`/`body` background — and previously relied on the browser's implicit **white** — now shows **black**. Set an explicit background in your page's CSS (e.g. `body { background: white; }`) to control it. Pages that already set a background are unaffected.
+
+> **Known limitations.**
+> - With multiple visible channels where a *lower* channel is transparent, colors in overlapping **semi-transparent** regions are approximate. A single transparent channel, or a transparent program sent to Syphon/recording, is exact.
+> - An active 2-channel transition **shader** won't carry alpha unless the shader itself preserves it.
 
 ---
 

--- a/scripts/ci/build-macos.sh
+++ b/scripts/ci/build-macos.sh
@@ -57,12 +57,15 @@ fi
 
 # Cargo feature flags for a given target. The face-detection feature pulls in
 # ONNX Runtime, which has no x86_64 macOS dylib, so disable it on that slice
-# (see spec/plugin-architecture.md, decision 5). The html feature uses Servo's
-# software RenderingContext (no per-arch/OS interop code), so it builds on the
-# x86_64 slice and is re-enabled explicitly there — see spec/html-source.md.
+# (see spec/plugin-architecture.md, decision 5). The html feature is also
+# disabled on x86_64: although Servo's software RenderingContext compiles for
+# x86_64, Servo deck-creation hangs under Rosetta at runtime, so the Intel slice
+# ships without HTML (matches .github/workflows/release.yml) — see
+# spec/html-source.md ("Platform Support"). HTML is Apple-Silicon-native only on
+# macOS (plus Linux x86_64).
 cargo_features_for() {
   case "$1" in
-    x86_64-apple-darwin) echo "--no-default-features --features html" ;;
+    x86_64-apple-darwin) echo "--no-default-features" ;;
     *) echo "" ;;
   esac
 }

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -153,6 +153,15 @@ impl VardaApp {
             });
         }
 
+        // Transparent compositing toggle — route through execute_command
+        for &(ch_idx, deck_idx, transparent) in &ui_actions.transparent_updates {
+            self.execute_command(EngineCommand::SetDeckTransparent {
+                channel_idx: ch_idx,
+                deck_idx,
+                transparent,
+            });
+        }
+
         // Render FPS updates — route through execute_command
         for &(ch_idx, deck_idx, render_fps) in &ui_actions.render_fps_updates {
             self.execute_command(EngineCommand::SetDeckRenderFps {
@@ -160,6 +169,27 @@ impl VardaApp {
                 deck_idx,
                 render_fps,
             });
+        }
+
+        // HTML deck reload — route through execute_command
+        for &(ch_idx, deck_idx) in &ui_actions.html_to_reload {
+            self.execute_command(EngineCommand::ReloadHtmlDeck {
+                channel_idx: ch_idx,
+                deck_idx,
+            });
+        }
+
+        // HTML interactive window open/close — route through execute_command
+        for &(ch_idx, deck_idx, open) in &ui_actions.html_set_interactive {
+            let cmd = if open {
+                EngineCommand::OpenHtmlInteractive {
+                    channel_idx: ch_idx,
+                    deck_idx,
+                }
+            } else {
+                EngineCommand::CloseHtmlInteractive
+            };
+            self.execute_command(cmd);
         }
 
         // Complex mutations — VardaApp methods

--- a/src/app/engine_impl.rs
+++ b/src/app/engine_impl.rs
@@ -302,6 +302,14 @@ impl MixerCommands for VardaApp {
         }
     }
 
+    fn set_deck_transparent(&mut self, channel_idx: usize, deck_idx: usize, transparent: bool) {
+        if let Some(ch) = self.mixer.channel_mut(channel_idx) {
+            if deck_idx < ch.decks.len() {
+                ch.decks[deck_idx].deck.set_transparent(transparent);
+            }
+        }
+    }
+
     fn set_channel_opacity(&mut self, channel_idx: usize, opacity: f32) {
         let opacity = sanitize_unit(opacity, 1.0);
         if let Some(ch) = self.mixer.channel_mut(channel_idx) {

--- a/src/app/interactive/input.rs
+++ b/src/app/interactive/input.rs
@@ -1,0 +1,315 @@
+//! winit → [`HtmlInputEvent`] translation for interactive HTML decks.
+//!
+//! All conversion from winit input types into the engine's `Send`
+//! [`HtmlInputEvent`] happens here so winit never reaches `internal/html`.
+//! Cursor positions are mapped from window logical coordinates to WebView
+//! **device** pixels (fixed 1:1, see `/spec/html-source.md` §4).
+//!
+//! Key/Code/NamedKey names follow the W3C UI Events spec in both winit and
+//! `keyboard_types`, so most map via `FromStr` on the variant name with a few
+//! documented special cases (winit `Super` ↔ W3C `Meta`). These are pure,
+//! stateless helpers; IME composition start/end tracking lives in the caller.
+
+use std::str::FromStr;
+
+use keyboard_types::{
+    Code, CompositionEvent, CompositionState, Key, KeyState, KeyboardEvent, Location, Modifiers,
+    NamedKey,
+};
+use winit::event::{ElementState, KeyEvent, MouseButton, MouseScrollDelta};
+use winit::keyboard::{
+    Key as WKey, KeyLocation, ModifiersState, NamedKey as WNamedKey, PhysicalKey,
+};
+
+use crate::html::HtmlInputEvent;
+
+/// Lines→pixels factor for `MouseScrollDelta::LineDelta` (typical UA line height).
+const LINE_HEIGHT_PX: f64 = 16.0;
+
+/// Map window logical cursor coords → WebView device-pixel point, clamped to the
+/// WebView size. `scale` is the window scale factor (device px per logical px).
+pub fn to_device_point(logical: (f64, f64), scale: f64, size: (u32, u32)) -> (f32, f32) {
+    let max_x = size.0.saturating_sub(1) as f64;
+    let max_y = size.1.saturating_sub(1) as f64;
+    let x = (logical.0 * scale).clamp(0.0, max_x);
+    let y = (logical.1 * scale).clamp(0.0, max_y);
+    (x as f32, y as f32)
+}
+
+/// DOM button index for a winit mouse button (0=left, 1=middle, 2=right, …).
+pub fn mouse_button_index(button: MouseButton) -> u16 {
+    match button {
+        MouseButton::Left => 0,
+        MouseButton::Middle => 1,
+        MouseButton::Right => 2,
+        MouseButton::Back => 3,
+        MouseButton::Forward => 4,
+        MouseButton::Other(n) => n,
+    }
+}
+
+/// A pointer-move event at a WebView device-pixel point.
+pub fn mouse_move(point: (f32, f32)) -> HtmlInputEvent {
+    HtmlInputEvent::MouseMove {
+        x: point.0,
+        y: point.1,
+    }
+}
+
+/// A mouse button press/release at a WebView device-pixel point.
+pub fn mouse_button(point: (f32, f32), button: MouseButton, state: ElementState) -> HtmlInputEvent {
+    HtmlInputEvent::MouseButton {
+        x: point.0,
+        y: point.1,
+        button: mouse_button_index(button),
+        pressed: state == ElementState::Pressed,
+    }
+}
+
+/// A wheel event in device pixels. winit and Servo agree on sign (positive = the
+/// view scrolls up/left, revealing earlier content), so deltas pass through.
+/// `PixelDelta` is already physical px; `LineDelta` is scaled by line height.
+pub fn wheel(point: (f32, f32), delta: MouseScrollDelta) -> HtmlInputEvent {
+    let (dx, dy) = match delta {
+        MouseScrollDelta::LineDelta(x, y) => (x as f64 * LINE_HEIGHT_PX, y as f64 * LINE_HEIGHT_PX),
+        MouseScrollDelta::PixelDelta(p) => (p.x, p.y),
+    };
+    HtmlInputEvent::Wheel {
+        x: point.0,
+        y: point.1,
+        dx,
+        dy,
+    }
+}
+
+/// Translate a winit key event (+ current modifiers) into a keyboard event.
+pub fn keyboard(event: &KeyEvent, mods: ModifiersState) -> HtmlInputEvent {
+    let state = match event.state {
+        ElementState::Pressed => KeyState::Down,
+        ElementState::Released => KeyState::Up,
+    };
+    let kt = KeyboardEvent {
+        state,
+        key: logical_key(&event.logical_key, event.text.as_deref()),
+        code: physical_code(event.physical_key),
+        location: key_location(event.location),
+        modifiers: modifiers(mods),
+        repeat: event.repeat,
+        is_composing: false,
+    };
+    HtmlInputEvent::Key(kt)
+}
+
+/// An IME preedit (composition) update. `start` marks the first event of a
+/// session (`compositionstart`); subsequent events are `compositionupdate`.
+pub fn ime_preedit(text: String, start: bool) -> HtmlInputEvent {
+    let state = if start {
+        CompositionState::Start
+    } else {
+        CompositionState::Update
+    };
+    HtmlInputEvent::Ime(CompositionEvent { state, data: text })
+}
+
+/// An IME commit (`compositionend`) — the composed text is inserted.
+pub fn ime_commit(text: String) -> HtmlInputEvent {
+    HtmlInputEvent::Ime(CompositionEvent {
+        state: CompositionState::End,
+        data: text,
+    })
+}
+
+fn logical_key(key: &WKey, text: Option<&str>) -> Key {
+    match key {
+        WKey::Character(s) => Key::Character(s.as_str().to_string()),
+        WKey::Named(WNamedKey::Space) => Key::Character(" ".to_string()),
+        WKey::Named(nk) => named_key(*nk),
+        WKey::Dead(_) => match text {
+            Some(t) if !t.is_empty() => Key::Character(t.to_string()),
+            _ => Key::Named(NamedKey::Unidentified),
+        },
+        WKey::Unidentified(_) => Key::Named(NamedKey::Unidentified),
+    }
+}
+
+fn named_key(nk: WNamedKey) -> Key {
+    // winit `Super` is the OS/Cmd/Win key; W3C / keyboard_types call it `Meta`.
+    if matches!(nk, WNamedKey::Super) {
+        return Key::Named(NamedKey::Meta);
+    }
+    Key::Named(NamedKey::from_str(&format!("{nk:?}")).unwrap_or(NamedKey::Unidentified))
+}
+
+fn physical_code(pk: PhysicalKey) -> Code {
+    match pk {
+        PhysicalKey::Code(kc) => {
+            // winit `SuperLeft`/`SuperRight` ↔ W3C `MetaLeft`/`MetaRight`.
+            let name = match format!("{kc:?}").as_str() {
+                "SuperLeft" => "MetaLeft".to_string(),
+                "SuperRight" => "MetaRight".to_string(),
+                other => other.to_string(),
+            };
+            Code::from_str(&name).unwrap_or(Code::Unidentified)
+        }
+        PhysicalKey::Unidentified(_) => Code::Unidentified,
+    }
+}
+
+fn key_location(loc: KeyLocation) -> Location {
+    match loc {
+        KeyLocation::Standard => Location::Standard,
+        KeyLocation::Left => Location::Left,
+        KeyLocation::Right => Location::Right,
+        KeyLocation::Numpad => Location::Numpad,
+    }
+}
+
+fn modifiers(m: ModifiersState) -> Modifiers {
+    let mut out = Modifiers::empty();
+    if m.shift_key() {
+        out |= Modifiers::SHIFT;
+    }
+    if m.control_key() {
+        out |= Modifiers::CONTROL;
+    }
+    if m.alt_key() {
+        out |= Modifiers::ALT;
+    }
+    if m.super_key() {
+        out |= Modifiers::META;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use winit::dpi::PhysicalPosition;
+    use winit::keyboard::KeyCode;
+
+    #[test]
+    fn device_point_scales_and_clamps() {
+        // 1:1 at scale 1.0 within bounds.
+        assert_eq!(to_device_point((10.0, 20.0), 1.0, (320, 240)), (10.0, 20.0));
+        // Scale factor applied (HiDPI).
+        assert_eq!(to_device_point((10.0, 20.0), 2.0, (640, 480)), (20.0, 40.0));
+        // Clamped to size-1 and to >= 0.
+        assert_eq!(
+            to_device_point((9999.0, -5.0), 1.0, (320, 240)),
+            (319.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn mouse_button_indices() {
+        assert_eq!(mouse_button_index(MouseButton::Left), 0);
+        assert_eq!(mouse_button_index(MouseButton::Middle), 1);
+        assert_eq!(mouse_button_index(MouseButton::Right), 2);
+        assert_eq!(mouse_button_index(MouseButton::Other(7)), 7);
+    }
+
+    #[test]
+    fn mouse_button_press_release() {
+        match mouse_button((1.0, 2.0), MouseButton::Left, ElementState::Pressed) {
+            HtmlInputEvent::MouseButton {
+                button, pressed, ..
+            } => {
+                assert_eq!(button, 0);
+                assert!(pressed);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        match mouse_button((1.0, 2.0), MouseButton::Right, ElementState::Released) {
+            HtmlInputEvent::MouseButton {
+                button, pressed, ..
+            } => {
+                assert_eq!(button, 2);
+                assert!(!pressed);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wheel_line_vs_pixel() {
+        match wheel((0.0, 0.0), MouseScrollDelta::LineDelta(0.0, 1.0)) {
+            HtmlInputEvent::Wheel { dy, .. } => assert_eq!(dy, LINE_HEIGHT_PX),
+            other => panic!("unexpected: {other:?}"),
+        }
+        match wheel(
+            (0.0, 0.0),
+            MouseScrollDelta::PixelDelta(PhysicalPosition::new(3.0, 4.0)),
+        ) {
+            HtmlInputEvent::Wheel { dx, dy, .. } => {
+                assert_eq!(dx, 3.0);
+                assert_eq!(dy, 4.0);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn logical_key_character_and_space() {
+        assert_eq!(
+            logical_key(&WKey::Character("a".into()), Some("a")),
+            Key::Character("a".to_string())
+        );
+        assert_eq!(
+            logical_key(&WKey::Named(WNamedKey::Space), Some(" ")),
+            Key::Character(" ".to_string())
+        );
+    }
+
+    #[test]
+    fn named_key_and_super_to_meta() {
+        assert_eq!(named_key(WNamedKey::Enter), Key::Named(NamedKey::Enter));
+        assert_eq!(named_key(WNamedKey::Escape), Key::Named(NamedKey::Escape));
+        assert_eq!(
+            named_key(WNamedKey::ArrowLeft),
+            Key::Named(NamedKey::ArrowLeft)
+        );
+        // winit Super maps to W3C Meta.
+        assert_eq!(named_key(WNamedKey::Super), Key::Named(NamedKey::Meta));
+    }
+
+    #[test]
+    fn physical_code_and_super_left_to_meta_left() {
+        assert_eq!(physical_code(PhysicalKey::Code(KeyCode::KeyA)), Code::KeyA);
+        assert_eq!(
+            physical_code(PhysicalKey::Code(KeyCode::Enter)),
+            Code::Enter
+        );
+        assert_eq!(
+            physical_code(PhysicalKey::Code(KeyCode::SuperLeft)),
+            Code::MetaLeft
+        );
+    }
+
+    #[test]
+    fn location_and_modifiers() {
+        assert_eq!(key_location(KeyLocation::Numpad), Location::Numpad);
+        assert_eq!(key_location(KeyLocation::Left), Location::Left);
+        let m = modifiers(ModifiersState::SHIFT | ModifiersState::SUPER);
+        assert!(m.contains(Modifiers::SHIFT));
+        assert!(m.contains(Modifiers::META));
+        assert!(!m.contains(Modifiers::CONTROL));
+    }
+
+    #[test]
+    fn ime_helpers() {
+        match ime_preedit("ni".to_string(), true) {
+            HtmlInputEvent::Ime(c) => {
+                assert_eq!(c.state, CompositionState::Start);
+                assert_eq!(c.data, "ni");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        match ime_commit("你".to_string()) {
+            HtmlInputEvent::Ime(c) => {
+                assert_eq!(c.state, CompositionState::End);
+                assert_eq!(c.data, "你");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+}

--- a/src/app/interactive/mod.rs
+++ b/src/app/interactive/mod.rs
@@ -1,0 +1,211 @@
+//! Interactive mode for HTML decks (feature `html`).
+//!
+//! A separate Varda-owned window displays a selected HTML deck's live page and
+//! forwards mouse/keyboard/scroll/IME input into the offscreen Servo `WebView`.
+//! See `/spec/html-source.md` §4. Only one interactive window exists at a time;
+//! it is fixed 1:1 to the deck's WebView size (non-resizable).
+
+pub(crate) mod input;
+mod window;
+
+use winit::dpi::PhysicalSize;
+use winit::window::Window;
+
+use crate::deck::ExternalSourceKind;
+use crate::engine::{CommandResult, ErrorCode};
+use crate::html::HtmlInputEvent;
+
+/// Resolved address + size of the HTML instance an interactive window drives.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InteractiveTarget {
+    pub channel_idx: usize,
+    pub deck_idx: usize,
+    pub html_idx: usize,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Engine-side state for the single interactive HTML window (one at a time).
+#[derive(Default)]
+pub(crate) struct InteractiveHtmlState {
+    /// Resolved open request, drained in the render loop (needs the event loop).
+    pending_open: Option<InteractiveTarget>,
+    /// Request to close the current window (set by command or `CloseRequested`).
+    pending_close: bool,
+    /// The live interactive window, if any.
+    window: Option<window::InteractiveWindow>,
+}
+
+impl super::VardaApp {
+    /// Open (or re-target) the interactive window for the HTML deck at
+    /// `(channel_idx, deck_idx)`. Window creation is deferred to the render loop.
+    pub(crate) fn cmd_open_html_interactive(
+        &mut self,
+        channel_idx: usize,
+        deck_idx: usize,
+    ) -> CommandResult {
+        let kind = self
+            .mixer
+            .channels()
+            .get(channel_idx)
+            .and_then(|ch| ch.decks.get(deck_idx))
+            .map(|slot| slot.deck.external_source_kind());
+        match kind {
+            Some(Some(ExternalSourceKind::Html(html_idx))) => {
+                // Already showing this deck → no-op.
+                if let Some(win) = &self.interactive.window {
+                    if win.target.channel_idx == channel_idx && win.target.deck_idx == deck_idx {
+                        return CommandResult::Ok;
+                    }
+                }
+                let (width, height) = self
+                    .external_io
+                    .html_manager
+                    .instance_dimensions(html_idx)
+                    .unwrap_or((1920, 1080));
+                // One at a time: close any existing window, then open the new one.
+                self.interactive.pending_close = true;
+                self.interactive.pending_open = Some(InteractiveTarget {
+                    channel_idx,
+                    deck_idx,
+                    html_idx,
+                    width,
+                    height,
+                });
+                CommandResult::Ok
+            }
+            Some(_) => CommandResult::Err {
+                code: ErrorCode::InvalidInput,
+                message: "Deck is not an HTML source".into(),
+            },
+            None => CommandResult::Err {
+                code: ErrorCode::NotFound,
+                message: "Deck not found".into(),
+            },
+        }
+    }
+
+    /// Close the interactive window (if any). Deferred to the render loop.
+    pub(crate) fn cmd_close_html_interactive(&mut self) -> CommandResult {
+        self.interactive.pending_open = None;
+        self.interactive.pending_close = true;
+        CommandResult::Ok
+    }
+
+    /// The `(channel_idx, deck_idx)` of the deck the interactive window is bound
+    /// to, if one is open. Used to reflect the toggle state in snapshots.
+    pub(crate) fn interactive_active_deck(&self) -> Option<(usize, usize)> {
+        self.interactive
+            .window
+            .as_ref()
+            .map(|w| (w.target.channel_idx, w.target.deck_idx))
+    }
+
+    /// Apply pending interactive open/close requests. Runs in the render loop so
+    /// it has the `ActiveEventLoop` needed to create a window. Mirrors
+    /// `create_pending_outputs` (`Box::leak` for `'static`; `destroy()` reclaims).
+    pub(crate) fn create_pending_interactive(
+        &mut self,
+        event_loop: &winit::event_loop::ActiveEventLoop,
+    ) {
+        if self.interactive.pending_close {
+            self.interactive.pending_close = false;
+            if let Some(win) = self.interactive.window.take() {
+                self.external_io
+                    .html_manager
+                    .send_input(win.target.html_idx, HtmlInputEvent::Focus(false));
+                win.destroy();
+            }
+        }
+        let Some(target) = self.interactive.pending_open.take() else {
+            return;
+        };
+        let attrs = Window::default_attributes()
+            .with_title("Varda — Interactive HTML")
+            .with_inner_size(PhysicalSize::new(target.width, target.height))
+            .with_resizable(false);
+        let window = match event_loop.create_window(attrs) {
+            Ok(w) => w,
+            Err(e) => {
+                log::error!("Failed to create interactive window: {e}");
+                self.session
+                    .notifications
+                    .warn(format!("Could not open interactive window: {e}"));
+                return;
+            }
+        };
+        let window_static: &'static Window = Box::leak(Box::new(window));
+        match window::InteractiveWindow::new(&self.context, window_static, target) {
+            Ok(win) => {
+                window_static.set_ime_allowed(true);
+                self.external_io
+                    .html_manager
+                    .send_input(target.html_idx, HtmlInputEvent::Focus(true));
+                log::info!(
+                    "Opened interactive HTML window for deck {}/{} ({}x{})",
+                    target.channel_idx,
+                    target.deck_idx,
+                    target.width,
+                    target.height
+                );
+                self.interactive.window = Some(win);
+            }
+            Err(e) => {
+                log::error!("Failed to init interactive window surface: {e}");
+                // Reclaim the leaked window box on failure.
+                let ptr = window_static as *const Window as *mut Window;
+                unsafe {
+                    let _ = Box::from_raw(ptr);
+                }
+            }
+        }
+    }
+
+    /// Route a winit window event to the interactive window. Returns `true` if
+    /// the event targeted the interactive window (and was consumed), so the
+    /// caller skips main/output handling. Mouse/keyboard/scroll/IME are
+    /// translated and forwarded to the servo thread; `CloseRequested` closes.
+    pub(crate) fn handle_interactive_event(
+        &mut self,
+        window_id: winit::window::WindowId,
+        event: &winit::event::WindowEvent,
+    ) -> bool {
+        let is_ours = self
+            .interactive
+            .window
+            .as_ref()
+            .is_some_and(|w| w.id() == window_id);
+        if !is_ours {
+            return false;
+        }
+        if matches!(event, winit::event::WindowEvent::CloseRequested) {
+            self.interactive.pending_close = true;
+            return true;
+        }
+        let html_idx = self.interactive.window.as_ref().unwrap().target.html_idx;
+        let events = self
+            .interactive
+            .window
+            .as_mut()
+            .unwrap()
+            .process_event(event);
+        for ev in events {
+            self.external_io.html_manager.send_input(html_idx, ev);
+        }
+        true
+    }
+
+    /// Blit the current HTML texture into the interactive window (per frame).
+    /// Call after `html_manager.update()` so the texture is fresh.
+    pub(crate) fn render_interactive(&self) {
+        if let Some(win) = &self.interactive.window {
+            if let Some(view) = self
+                .external_io
+                .html_manager
+                .texture_view(win.target.html_idx)
+            {
+                win.render(&self.context, view);
+            }
+        }
+    }
+}

--- a/src/app/interactive/window.rs
+++ b/src/app/interactive/window.rs
@@ -1,0 +1,211 @@
+//! The interactive HTML window: a lightweight winit/wgpu window that blits a
+//! deck's live HTML texture and carries the input state needed to forward
+//! mouse/keyboard/scroll/IME into the offscreen Servo `WebView`.
+//!
+//! It is fixed 1:1 to the deck's WebView size and non-resizable (see
+//! `/spec/html-source.md` §4), so the surface and the WebView share a device
+//! pixel grid and cursor mapping is the identity (plus clamping). Modeled on
+//! `OutputWindow` but display-only — it never joins `output.outputs`.
+
+use anyhow::{Context, Result};
+use winit::event::WindowEvent;
+use winit::keyboard::ModifiersState;
+use winit::window::Window;
+
+use super::{input, InteractiveTarget};
+use crate::html::HtmlInputEvent;
+use crate::renderer::blit::BlitPipeline;
+use crate::renderer::context::GpuContext;
+
+/// One interactive window driving a single HTML instance.
+pub(crate) struct InteractiveWindow {
+    window: &'static Window,
+    surface: wgpu::Surface<'static>,
+    surface_config: wgpu::SurfaceConfiguration,
+    blit_pipeline: BlitPipeline,
+    /// Deck/instance this window drives.
+    pub(crate) target: InteractiveTarget,
+    /// Last known cursor position in physical (== WebView device) pixels.
+    pub(crate) cursor: (f64, f64),
+    /// Currently-held modifier keys.
+    pub(crate) modifiers: ModifiersState,
+    /// True while an IME composition session is in progress.
+    pub(crate) composing: bool,
+}
+
+impl InteractiveWindow {
+    /// Create the window's surface + blit pipeline, sharing the engine device.
+    pub(crate) fn new(
+        context: &GpuContext,
+        window: &'static Window,
+        target: InteractiveTarget,
+    ) -> Result<Self> {
+        let size = window.inner_size();
+        let surface = context
+            .instance
+            .create_surface(window)
+            .context("Failed to create interactive surface")?;
+        let caps = surface.get_capabilities(&context.adapter);
+        let format = caps
+            .formats
+            .iter()
+            .copied()
+            .find(|f| f.is_srgb())
+            .unwrap_or(caps.formats[0]);
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width: size.width.max(1),
+            height: size.height.max(1),
+            present_mode: wgpu::PresentMode::Fifo,
+            alpha_mode: caps.alpha_modes[0],
+            view_formats: vec![],
+            desired_maximum_frame_latency: 2,
+        };
+        surface.configure(&context.device, &surface_config);
+        let blit_pipeline = BlitPipeline::new(&context.device, surface_config.format)?;
+        Ok(Self {
+            window,
+            surface,
+            surface_config,
+            blit_pipeline,
+            target,
+            cursor: (0.0, 0.0),
+            modifiers: ModifiersState::empty(),
+            composing: false,
+        })
+    }
+
+    /// This window's winit id, for event routing.
+    pub(crate) fn id(&self) -> winit::window::WindowId {
+        self.window.id()
+    }
+
+    /// WebView size in device pixels (for coordinate clamping).
+    pub(crate) fn webview_size(&self) -> (u32, u32) {
+        (self.target.width, self.target.height)
+    }
+
+    /// Translate a winit window event into input events for the WebView,
+    /// updating tracked cursor/modifier/composition state. Returns the events to
+    /// forward to the servo thread (usually 0 or 1). `CloseRequested` is handled
+    /// by the caller; unhandled events return empty.
+    pub(crate) fn process_event(&mut self, event: &WindowEvent) -> Vec<HtmlInputEvent> {
+        match event {
+            WindowEvent::CursorMoved { position, .. } => {
+                self.cursor = (position.x, position.y);
+                let p = input::to_device_point(self.cursor, 1.0, self.webview_size());
+                vec![input::mouse_move(p)]
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                let p = input::to_device_point(self.cursor, 1.0, self.webview_size());
+                vec![input::mouse_button(p, *button, *state)]
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                let p = input::to_device_point(self.cursor, 1.0, self.webview_size());
+                vec![input::wheel(p, *delta)]
+            }
+            WindowEvent::ModifiersChanged(m) => {
+                self.modifiers = m.state();
+                vec![]
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                vec![input::keyboard(event, self.modifiers)]
+            }
+            WindowEvent::Ime(ime) => self.process_ime(ime),
+            WindowEvent::Focused(focused) => vec![HtmlInputEvent::Focus(*focused)],
+            _ => vec![],
+        }
+    }
+
+    /// IME → composition events, tracking the start/update/end session lifecycle.
+    fn process_ime(&mut self, ime: &winit::event::Ime) -> Vec<HtmlInputEvent> {
+        use winit::event::Ime;
+        match ime {
+            Ime::Enabled => vec![],
+            Ime::Preedit(text, _) if text.is_empty() => {
+                if std::mem::take(&mut self.composing) {
+                    vec![HtmlInputEvent::ImeDismissed]
+                } else {
+                    vec![]
+                }
+            }
+            Ime::Preedit(text, _) => {
+                let start = !self.composing;
+                self.composing = true;
+                vec![input::ime_preedit(text.clone(), start)]
+            }
+            Ime::Commit(text) => {
+                self.composing = false;
+                vec![input::ime_commit(text.clone())]
+            }
+            Ime::Disabled => {
+                if std::mem::take(&mut self.composing) {
+                    vec![HtmlInputEvent::ImeDismissed]
+                } else {
+                    vec![]
+                }
+            }
+        }
+    }
+
+    /// Blit the current HTML texture into the window surface (1:1 fullscreen).
+    pub(crate) fn render(&self, context: &GpuContext, html_view: &wgpu::TextureView) {
+        let frame = match self.surface.get_current_texture() {
+            wgpu::CurrentSurfaceTexture::Success(f)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(f) => f,
+            wgpu::CurrentSurfaceTexture::Outdated => {
+                self.surface
+                    .configure(&context.device, &self.surface_config);
+                return;
+            }
+            other => {
+                log::debug!("Interactive surface unavailable: {other:?}");
+                return;
+            }
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let bind_group = self
+            .blit_pipeline
+            .create_bind_group(&context.device, html_view);
+        let mut encoder = context
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Interactive Encoder"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Interactive Blit"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            self.blit_pipeline.render(&mut pass, &bind_group);
+        }
+        context.queue.submit(std::iter::once(encoder.finish()));
+        frame.present();
+        self.window.request_redraw();
+    }
+
+    /// Close the OS window and reclaim the leaked `Box<Window>` (mirrors
+    /// `OutputWindow::destroy`). Sole owner after removal from app state.
+    pub(crate) fn destroy(self) {
+        let window_ptr = self.window as *const Window as *mut Window;
+        drop(self.surface);
+        unsafe {
+            let _ = Box::from_raw(window_ptr);
+        }
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,6 +9,9 @@ mod actions;
 mod engine_impl;
 pub(crate) mod history;
 mod inputs;
+/// Interactive mode for HTML decks (feature `html`). See /spec/html-source.md §4.
+#[cfg(feature = "html")]
+pub(crate) mod interactive;
 mod outputs;
 pub(crate) mod render;
 mod snapshot;
@@ -218,6 +221,9 @@ pub struct VardaApp {
     pub(crate) input: InputSubsystem,
     pub(crate) output: OutputSubsystem,
     pub(crate) external_io: ExternalIO,
+    /// Interactive HTML window state (feature `html`). See /spec/html-source.md §4.
+    #[cfg(feature = "html")]
+    pub(crate) interactive: interactive::InteractiveHtmlState,
     pub(crate) frame_stats: FrameStats,
     pub(crate) session: SessionState,
     pub(crate) bus: MessageBus,
@@ -458,6 +464,8 @@ impl VardaApp {
                 state_tx,
             },
             audio_textures,
+            #[cfg(feature = "html")]
+            interactive: interactive::InteractiveHtmlState::default(),
             render_width: DEFAULT_RENDER_WIDTH,
             render_height: DEFAULT_RENDER_HEIGHT,
             target_fps: config.target_fps,
@@ -689,6 +697,14 @@ impl VardaApp {
                 mode,
             } => {
                 self.set_deck_scaling_mode(channel_idx, deck_idx, mode);
+                CommandResult::Ok
+            }
+            EngineCommand::SetDeckTransparent {
+                channel_idx,
+                deck_idx,
+                transparent,
+            } => {
+                self.set_deck_transparent(channel_idx, deck_idx, transparent);
                 CommandResult::Ok
             }
             EngineCommand::SetChannelOpacity {
@@ -1231,8 +1247,39 @@ impl VardaApp {
                 url,
                 mode,
             } => self.cmd_add_rtmp_deck(channel_idx, url, mode),
+            EngineCommand::ReloadHtmlDeck {
+                channel_idx,
+                deck_idx,
+            } => self.cmd_reload_html_deck(channel_idx, deck_idx),
             EngineCommand::AddHtmlDeck { channel_idx, url } => {
                 self.cmd_add_html_deck(channel_idx, url)
+            }
+            EngineCommand::OpenHtmlInteractive {
+                channel_idx,
+                deck_idx,
+            } => {
+                #[cfg(feature = "html")]
+                {
+                    self.cmd_open_html_interactive(channel_idx, deck_idx)
+                }
+                #[cfg(not(feature = "html"))]
+                {
+                    let _ = (channel_idx, deck_idx);
+                    crate::engine::CommandResult::Err {
+                        code: crate::engine::ErrorCode::InvalidInput,
+                        message: "HTML feature not built".into(),
+                    }
+                }
+            }
+            EngineCommand::CloseHtmlInteractive => {
+                #[cfg(feature = "html")]
+                {
+                    self.cmd_close_html_interactive()
+                }
+                #[cfg(not(feature = "html"))]
+                {
+                    crate::engine::CommandResult::Ok
+                }
             }
 
             // ── Transition Sequences ──────────────────────────

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -85,11 +85,26 @@ pub(crate) fn build_mixer_snapshot(app: &VardaApp) -> MixerSnapshot {
                         idx: deck_idx,
                         uuid: slot.deck.uuid().to_string(),
                         name: slot.deck.source_name().to_string(),
+                        is_html: matches!(
+                            slot.deck.external_source_kind(),
+                            Some(crate::deck::ExternalSourceKind::Html(_))
+                        ),
+                        is_html_interactive: {
+                            #[cfg(feature = "html")]
+                            {
+                                app.interactive_active_deck() == Some((ch_idx, deck_idx))
+                            }
+                            #[cfg(not(feature = "html"))]
+                            {
+                                false
+                            }
+                        },
                         opacity: slot.opacity,
                         effective_opacity,
                         blend_mode: slot.blend_mode,
                         solo: slot.solo,
                         mute: slot.mute,
+                        transparent: slot.deck.transparent(),
                         scaling_mode: slot.deck.scaling_mode(),
                         generator: gen_params,
                         effects,
@@ -552,11 +567,14 @@ pub(crate) fn build_ui_data(
                         deck_idx: d.idx,
                         uuid: d.uuid.clone(),
                         name: d.name.clone(),
+                        is_html: d.is_html,
+                        is_html_interactive: d.is_html_interactive,
                         opacity: d.opacity,
                         effective_opacity: d.effective_opacity,
                         blend_mode: d.blend_mode,
                         solo: d.solo,
                         mute: d.mute,
+                        transparent: d.transparent,
                         scaling_mode: d.scaling_mode,
                         generator,
                         effects,

--- a/src/app/state/io.rs
+++ b/src/app/state/io.rs
@@ -269,6 +269,30 @@ impl VardaApp {
         }
     }
 
+    /// Reload the HTML deck at `(channel_idx, deck_idx)`, re-fetching its URL.
+    pub fn cmd_reload_html_deck(&mut self, channel_idx: usize, deck_idx: usize) -> CommandResult {
+        let kind = self
+            .mixer
+            .channels()
+            .get(channel_idx)
+            .and_then(|ch| ch.decks.get(deck_idx))
+            .map(|slot| slot.deck.external_source_kind());
+        match kind {
+            Some(Some(crate::deck::ExternalSourceKind::Html(idx))) => {
+                self.external_io.html_manager.reload(idx);
+                CommandResult::Ok
+            }
+            Some(_) => CommandResult::Err {
+                code: ErrorCode::InvalidInput,
+                message: "Deck is not an HTML source".into(),
+            },
+            None => CommandResult::Err {
+                code: ErrorCode::NotFound,
+                message: "Deck not found".into(),
+            },
+        }
+    }
+
     pub fn cmd_add_dash_deck(&mut self, channel_idx: usize, url: String) -> CommandResult {
         match self.external_io.stream_manager.start_receive(
             &url,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -129,6 +129,11 @@ pub enum EngineCommand {
         deck_idx: usize,
         mode: ScalingMode,
     },
+    SetDeckTransparent {
+        channel_idx: usize,
+        deck_idx: usize,
+        transparent: bool,
+    },
     SetChannelOpacity {
         channel_idx: usize,
         opacity: f32,
@@ -319,6 +324,17 @@ pub enum EngineCommand {
         channel_idx: usize,
         url: String,
     },
+    ReloadHtmlDeck {
+        channel_idx: usize,
+        deck_idx: usize,
+    },
+    /// Open the interactive window for the HTML deck at `(channel_idx, deck_idx)`.
+    OpenHtmlInteractive {
+        channel_idx: usize,
+        deck_idx: usize,
+    },
+    /// Close the interactive HTML window (if any).
+    CloseHtmlInteractive,
 
     // ── Transition Sequences ───────────────────────────────────
     CreateSequence,

--- a/src/engine/traits.rs
+++ b/src/engine/traits.rs
@@ -29,6 +29,7 @@ pub trait MixerCommands {
     fn set_deck_solo(&mut self, channel_idx: usize, deck_idx: usize, solo: bool);
     fn set_deck_mute(&mut self, channel_idx: usize, deck_idx: usize, mute: bool);
     fn set_deck_scaling_mode(&mut self, channel_idx: usize, deck_idx: usize, mode: ScalingMode);
+    fn set_deck_transparent(&mut self, channel_idx: usize, deck_idx: usize, transparent: bool);
     fn set_channel_opacity(&mut self, channel_idx: usize, opacity: f32);
     fn set_channel_blend_mode(&mut self, channel_idx: usize, mode: BlendMode);
     fn add_channel(&mut self) -> Result<usize>;

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -156,11 +156,17 @@ pub struct DeckSnapshot {
     pub idx: usize,
     pub uuid: String,
     pub name: String,
+    /// True when this deck's source is an HTML/Servo instance.
+    pub is_html: bool,
+    /// True when the interactive window is currently open for this deck.
+    pub is_html_interactive: bool,
     pub opacity: f32,
     pub effective_opacity: f32,
     pub blend_mode: BlendMode,
     pub solo: bool,
     pub mute: bool,
+    /// True when this deck preserves source alpha (transparent compositing).
+    pub transparent: bool,
     pub scaling_mode: Option<ScalingMode>,
     pub generator: ShaderParamsSnapshot,
     pub effects: Vec<EffectSnapshot>,
@@ -744,11 +750,14 @@ mod tests {
             idx: 0,
             uuid: "test0002".into(),
             name: "Sine Wave".into(),
+            is_html: false,
+            is_html_interactive: false,
             opacity: 1.0,
             effective_opacity: 0.5,
             blend_mode: BlendMode::Normal,
             solo: false,
             mute: true,
+            transparent: false,
             scaling_mode: Some(ScalingMode::default()),
             generator: ShaderParamsSnapshot {
                 shader_name: "Sine".into(),

--- a/src/internal/deck/mod.rs
+++ b/src/internal/deck/mod.rs
@@ -281,7 +281,13 @@ pub enum DeckSource {
     /// External live source (camera, NDI, Syphon, SRT, HLS, DASH, RTMP)
     ExternalSource {
         kind: ExternalSourceKind,
+        /// REPLACE blit — writes the source's straight RGBA verbatim. Used when
+        /// the deck is flagged `transparent` (preserves source alpha).
         blit_pipeline: BlitPipeline,
+        /// ALPHA_BLENDING blit over an opaque black clear — flattens the source
+        /// to opaque. Used by default (unflagged), so an HTML source with alpha<1
+        /// composites over black instead of punching transparent holes.
+        blit_pipeline_over_black: BlitPipeline,
         source_width: u32,
         source_height: u32,
         scaling_mode: ScalingMode,
@@ -427,6 +433,12 @@ pub struct Deck {
 
     /// Deck opacity (0.0 - 1.0)
     pub opacity: f32,
+
+    /// When true, the deck's base texture preserves source alpha (transparent
+    /// letterbox + transparent HTML regions). When false (default), the source is
+    /// composited over opaque black, reproducing the historical opaque behavior.
+    /// See /spec/html-source.md §2 (Option A).
+    transparent: bool,
 
     /// Accumulated render time for TIME uniform (advances by fixed dt each render).
     /// Decoupled from wall clock so skipped frames don't cause animation jumps.
@@ -622,6 +634,16 @@ impl Deck {
             | DeckSource::ExternalSource { scaling_mode, .. } => *scaling_mode = mode,
             _ => {}
         }
+    }
+
+    /// Whether this deck preserves source alpha (transparent compositing).
+    pub fn transparent(&self) -> bool {
+        self.transparent
+    }
+
+    /// Set whether this deck preserves source alpha (transparent compositing).
+    pub fn set_transparent(&mut self, transparent: bool) {
+        self.transparent = transparent;
     }
 
     /// Get the external source kind (if source is external)

--- a/src/internal/deck/render.rs
+++ b/src/internal/deck/render.rs
@@ -530,6 +530,7 @@ impl Deck {
             DeckSource::ExternalSource {
                 kind,
                 blit_pipeline,
+                blit_pipeline_over_black,
                 source_width,
                 source_height,
                 scaling_mode,
@@ -538,6 +539,8 @@ impl Deck {
                     Self::blit_external_source(
                         context,
                         blit_pipeline,
+                        blit_pipeline_over_black,
+                        self.transparent,
                         ext_view,
                         *source_width,
                         *source_height,
@@ -1071,6 +1074,8 @@ impl Deck {
     fn blit_external_source(
         context: &GpuContext,
         blit_pipeline: &BlitPipeline,
+        blit_pipeline_over_black: &BlitPipeline,
+        transparent: bool,
         source_view: &wgpu::TextureView,
         source_width: u32,
         source_height: u32,
@@ -1081,15 +1086,25 @@ impl Deck {
         label: &str,
         cmd_buffers: &mut Vec<wgpu::CommandBuffer>,
     ) {
+        // Flagged transparent → REPLACE over a transparent clear, preserving the
+        // source's straight alpha (and leaving letterbox transparent). Default →
+        // ALPHA_BLENDING over an opaque black clear, flattening to opaque so an
+        // HTML source with alpha<1 doesn't punch holes (/spec/html-source.md §2).
+        let (pipeline, clear) = if transparent {
+            (blit_pipeline, wgpu::Color::TRANSPARENT)
+        } else {
+            (blit_pipeline_over_black, wgpu::Color::BLACK)
+        };
+
         let (uv_scale, uv_offset) = scaling_mode.compute_uv_transform(
             source_width,
             source_height,
             target_width,
             target_height,
         );
-        blit_pipeline.set_uv_transform(&context.queue, 1.0, uv_scale, uv_offset);
+        pipeline.set_uv_transform(&context.queue, 1.0, uv_scale, uv_offset);
 
-        let bind_group = blit_pipeline.create_bind_group(&context.device, source_view);
+        let bind_group = pipeline.create_bind_group(&context.device, source_view);
         let mut encoder = context
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -1102,7 +1117,7 @@ impl Deck {
                     view: generator_target,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        load: wgpu::LoadOp::Clear(clear),
                         store: wgpu::StoreOp::Store,
                     },
                     depth_slice: None,
@@ -1112,7 +1127,7 @@ impl Deck {
                 occlusion_query_set: None,
                 multiview_mask: None,
             });
-            blit_pipeline.render(&mut render_pass, &bind_group);
+            pipeline.render(&mut render_pass, &bind_group);
         }
         cmd_buffers.push(encoder.finish());
     }

--- a/src/internal/deck/source.rs
+++ b/src/internal/deck/source.rs
@@ -14,6 +14,21 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
+/// Create the pair of blit pipelines used by every external/live source deck:
+/// `(replace, over_black)`. The REPLACE pipeline writes the source's straight
+/// RGBA verbatim (used when the deck is flagged `transparent`, preserving alpha);
+/// the ALPHA_BLENDING pipeline flattens the source over an opaque black clear (the
+/// default, so an HTML source with alpha<1 stays opaque). See /spec/html-source.md §2.
+fn external_blit_pipelines(context: &GpuContext) -> Result<(BlitPipeline, BlitPipeline)> {
+    let replace = BlitPipeline::new(&context.device, wgpu::TextureFormat::Rgba8Unorm)?;
+    let over_black = BlitPipeline::with_blend(
+        &context.device,
+        wgpu::TextureFormat::Rgba8Unorm,
+        wgpu::BlendState::ALPHA_BLENDING,
+    )?;
+    Ok((replace, over_black))
+}
+
 /// Load ISF IMPORTED images from metadata and create GPU textures.
 /// Returns (name, texture, view) sorted alphabetically by name for deterministic binding order.
 ///
@@ -343,6 +358,7 @@ impl Deck {
             texture_b_view,
             effects: Vec::new(),
             opacity: 1.0,
+            transparent: false,
             render_time: 0.0,
             render_dt: 1.0 / 60.0,
             frame_count: 0,
@@ -730,11 +746,12 @@ impl Deck {
         height: u32,
     ) -> Result<Self> {
         let source_name = format!("📹 {}", camera_name);
-        let blit_pipeline = BlitPipeline::new(&context.device, wgpu::TextureFormat::Rgba8Unorm)?;
+        let (blit_pipeline, blit_pipeline_over_black) = external_blit_pipelines(context)?;
 
         let source = DeckSource::ExternalSource {
             kind: ExternalSourceKind::Camera(camera_id),
             blit_pipeline,
+            blit_pipeline_over_black,
             source_width,
             source_height,
             scaling_mode: ScalingMode::default(),
@@ -807,6 +824,7 @@ impl Deck {
             texture_b_view,
             effects: Vec::new(),
             opacity: 1.0,
+            transparent: false,
             render_time: 0.0,
             render_dt: 1.0 / 60.0,
             frame_count: 0,
@@ -829,11 +847,12 @@ impl Deck {
         width: u32,
         height: u32,
     ) -> Result<Self> {
-        let blit_pipeline = BlitPipeline::new(&context.device, wgpu::TextureFormat::Rgba8Unorm)?;
+        let (blit_pipeline, blit_pipeline_over_black) = external_blit_pipelines(context)?;
 
         let source = DeckSource::ExternalSource {
             kind,
             blit_pipeline,
+            blit_pipeline_over_black,
             source_width,
             source_height,
             scaling_mode: ScalingMode::default(),
@@ -1094,6 +1113,7 @@ impl Deck {
             texture_b_view,
             effects: Vec::new(),
             opacity: 1.0,
+            transparent: false,
             render_time: 0.0,
             render_dt: 1.0 / 60.0,
             frame_count: 0,

--- a/src/internal/html/mod.rs
+++ b/src/internal/html/mod.rs
@@ -32,6 +32,38 @@ struct HtmlFrame {
 /// thread (reader), mirroring the NDI/stream `Arc<Mutex<Option<…>>>` pattern.
 type FrameSlot = Arc<Mutex<Option<HtmlFrame>>>;
 
+/// A single interactive-mode input event forwarded from an interactive window to
+/// the owning servo thread (feature `html`). Carries only `Send` data plus
+/// `keyboard_types` values; the winit→here translation lives in the app layer so
+/// winit never reaches this module, preserving the "only `Send` data crosses the
+/// thread boundary" contract. Positions are WebView **device** pixels. See
+/// `/spec/html-source.md` §4.
+#[cfg(feature = "html")]
+#[derive(Debug, Clone)]
+pub enum HtmlInputEvent {
+    /// Pointer moved to a WebView device-pixel position.
+    MouseMove { x: f32, y: f32 },
+    /// Mouse button pressed/released. `button`: 0=left, 1=middle, 2=right.
+    MouseButton {
+        x: f32,
+        y: f32,
+        button: u16,
+        pressed: bool,
+    },
+    /// Wheel delta (DOM `wheel` event) in device pixels.
+    Wheel { x: f32, y: f32, dx: f64, dy: f64 },
+    /// Scroll the page by a device-pixel delta at a position.
+    Scroll { x: f32, y: f32, dx: f64, dy: f64 },
+    /// A translated keyboard event.
+    Key(keyboard_types::KeyboardEvent),
+    /// An IME composition update (preedit start/update or commit end).
+    Ime(keyboard_types::CompositionEvent),
+    /// IME composition dismissed/cancelled.
+    ImeDismissed,
+    /// Window focus gained/lost → `WebView::focus()`/`blur()`.
+    Focus(bool),
+}
+
 /// Manages offscreen HTML render instances and their destination GPU textures.
 ///
 /// Mirrors the shape of `NdiManager` / `StreamManager`: the render loop calls
@@ -257,6 +289,26 @@ impl HtmlManager {
         }
     }
 
+    /// Reload an existing instance, re-fetching its current URL.
+    pub fn reload(&mut self, idx: usize) {
+        if let Some(instance) = self.instances.get_mut(idx) {
+            instance.initialized = false;
+            #[cfg(feature = "html")]
+            if let Some(engine) = self.engine.as_ref() {
+                engine.reload(instance.id);
+            }
+        }
+    }
+
+    /// Forward an interactive-mode input event to the instance at `idx`.
+    /// No-op for an unknown index or when no engine has been spawned.
+    #[cfg(feature = "html")]
+    pub fn send_input(&self, idx: usize, event: HtmlInputEvent) {
+        if let (Some(instance), Some(engine)) = (self.instances.get(idx), self.engine.as_ref()) {
+            engine.send_input(instance.id, event);
+        }
+    }
+
     /// Stop and drop the instance at `idx`. Note: indices of later instances are
     /// not preserved — callers that hold indices should treat this as teardown.
     pub fn stop_render(&mut self, idx: usize) {
@@ -273,16 +325,12 @@ impl HtmlManager {
     }
 }
 
-/// A neutral dark-gray opaque placeholder used when no frame is available.
+/// A fully transparent placeholder used when no frame is available. Transparent
+/// (rather than opaque dark-gray) so that on a deck flagged `transparent` the
+/// pre-first-frame window shows through; an unflagged deck composites it over the
+/// opaque black base clear, yielding black (see /spec/html-source.md §2).
 fn placeholder_frame(width: u32, height: u32) -> Vec<u8> {
-    let mut buf = vec![0u8; (width * height * 4) as usize];
-    for px in buf.chunks_exact_mut(4) {
-        px[0] = 24;
-        px[1] = 24;
-        px[2] = 28;
-        px[3] = 255;
-    }
-    buf
+    vec![0u8; (width * height * 4) as usize]
 }
 
 #[cfg(test)]
@@ -312,10 +360,33 @@ mod tests {
     }
 
     #[test]
-    fn placeholder_frame_is_opaque_and_sized() {
+    fn reload_out_of_range_is_noop() {
+        // Reloading a non-existent instance must not panic (no engine spawned).
+        let mut mgr = HtmlManager::new();
+        mgr.reload(0);
+        mgr.reload(999);
+        let mut disabled = HtmlManager::new_disabled();
+        disabled.reload(0);
+    }
+
+    #[cfg(feature = "html")]
+    #[test]
+    fn send_input_out_of_range_is_noop() {
+        // Forwarding input to a non-existent instance must not panic (no engine).
+        let mgr = HtmlManager::new();
+        mgr.send_input(0, HtmlInputEvent::MouseMove { x: 1.0, y: 2.0 });
+        mgr.send_input(999, HtmlInputEvent::Focus(true));
+        let disabled = HtmlManager::new_disabled();
+        disabled.send_input(0, HtmlInputEvent::Focus(false));
+    }
+
+    #[test]
+    fn placeholder_frame_is_transparent_and_sized() {
         let buf = placeholder_frame(4, 2);
         assert_eq!(buf.len(), 4 * 2 * 4);
-        assert!(buf.chunks_exact(4).all(|px| px[3] == 255));
+        // Fully transparent (all channels 0) so a `transparent` deck shows through
+        // before its first Servo frame; see /spec/html-source.md §2.
+        assert!(buf.iter().all(|&b| b == 0));
     }
 }
 
@@ -487,6 +558,136 @@ done=true;}},120);</script></body></html>";
         assert!(
             is_color(px, [0, 0, 255]),
             "setInterval idle DOM update was not repainted; got {px:?}"
+        );
+    }
+
+    /// Reload correctness: after a page has rendered, `reload()` re-fetches the
+    /// current URL and re-executes its JS, repainting the same content without
+    /// error. Proves the `HtmlCommand::Reload` → `WebView::reload()` path drives a
+    /// fresh paint on a live, settled instance.
+    #[test]
+    #[ignore = "heavy: starts a real Servo engine; run with --ignored --test-threads=1"]
+    fn html_deck_reload_repaints() {
+        let Ok(gpu) = GpuContext::new_headless() else {
+            eprintln!("skipping: no GPU adapter available");
+            return;
+        };
+        let mut mgr = HtmlManager::new();
+
+        // CSS paints black, JS overrides to blue — reaching blue proves JS ran.
+        let css_js = "<!doctype html><html><head><style>html,body{height:100%;margin:0}body{background:#000}</style></head><body><script>document.body.style.background='rgb(0,0,255)';</script></body></html>";
+        let idx = mgr
+            .start_render(&data_url(css_js), W, H, &gpu.device)
+            .expect("start_render returned None with the html feature enabled");
+        let px = pump_until(&gpu, &mut mgr, idx, [0, 0, 255], Duration::from_secs(30));
+        assert!(
+            is_color(px, [0, 0, 255]),
+            "deck did not render blue; got {px:?}"
+        );
+
+        // Reload re-fetches the same URL and re-runs the JS; it must paint blue again.
+        mgr.reload(idx);
+        let px2 = pump_until(&gpu, &mut mgr, idx, [0, 0, 255], Duration::from_secs(30));
+        assert!(
+            is_color(px2, [0, 0, 255]),
+            "deck did not repaint blue after reload; got {px2:?}"
+        );
+    }
+
+    /// Interactive input correctness: a forwarded mouse click reaches the DOM.
+    /// The page paints red and registers a `click` handler that flips it blue;
+    /// after `send_input` delivers MouseMove + button down/up at the center, the
+    /// deck must repaint blue. Proves the `HtmlInputEvent` → `HtmlCommand::Input`
+    /// → `WebView::notify_input_event` path drives a real DOM event + repaint.
+    #[test]
+    #[ignore = "heavy: starts a real Servo engine; run with --ignored --test-threads=1"]
+    fn html_deck_click_input_repaints() {
+        let Ok(gpu) = GpuContext::new_headless() else {
+            eprintln!("skipping: no GPU adapter available");
+            return;
+        };
+        let mut mgr = HtmlManager::new();
+
+        // Paints red; a document-level click handler flips the background to blue.
+        let page = "<!doctype html><html><head><style>html,body{height:100%;margin:0}\
+body{background:red}</style></head><body><script>\
+document.addEventListener('click',function(){\
+document.body.style.background='rgb(0,0,255)';});</script></body></html>";
+        let idx = mgr
+            .start_render(&data_url(page), W, H, &gpu.device)
+            .expect("start_render returned None with the html feature enabled");
+
+        // Wait for the page's red paint (distinct from the gray placeholder) so
+        // the document is loaded and interactive before we click.
+        let red = pump_until(&gpu, &mut mgr, idx, [255, 0, 0], Duration::from_secs(30));
+        assert!(
+            is_color(red, [255, 0, 0]),
+            "page did not render red; got {red:?}"
+        );
+
+        // Forward a click at the viewport center: move, press, release.
+        let (cx, cy) = ((W / 2) as f32, (H / 2) as f32);
+        mgr.send_input(idx, HtmlInputEvent::MouseMove { x: cx, y: cy });
+        mgr.send_input(
+            idx,
+            HtmlInputEvent::MouseButton {
+                x: cx,
+                y: cy,
+                button: 0,
+                pressed: true,
+            },
+        );
+        mgr.send_input(
+            idx,
+            HtmlInputEvent::MouseButton {
+                x: cx,
+                y: cy,
+                button: 0,
+                pressed: false,
+            },
+        );
+
+        let px = pump_until(&gpu, &mut mgr, idx, [0, 0, 255], Duration::from_secs(30));
+        assert!(
+            is_color(px, [0, 0, 255]),
+            "forwarded click did not repaint blue; got {px:?}"
+        );
+    }
+
+    /// Transparency correctness (Blocker 1): with `shell_background_color_rgba`
+    /// set to `[0,0,0,0]`, a page whose html/body are transparent must read back
+    /// with alpha below 255 — proving the Servo viewport clears transparent rather
+    /// than the default opaque white. See /spec/html-source.md §2.
+    #[test]
+    #[ignore = "heavy: starts a real Servo engine; run with --ignored --test-threads=1"]
+    fn html_deck_transparent_background_has_alpha() {
+        let Ok(gpu) = GpuContext::new_headless() else {
+            eprintln!("skipping: no GPU adapter available");
+            return;
+        };
+        let mut mgr = HtmlManager::new();
+
+        // Explicitly transparent html/body; no opaque content anywhere.
+        let page = "<!doctype html><html><head><style>html,body{height:100%;margin:0;\
+background:transparent}</style></head><body></body></html>";
+        let idx = mgr
+            .start_render(&data_url(page), W, H, &gpu.device)
+            .expect("start_render returned None with the html feature enabled");
+
+        // Pump until the center pixel reads transparent (alpha < 255), or time out.
+        let start = Instant::now();
+        let mut px = [255u8; 4];
+        while start.elapsed() < Duration::from_secs(30) {
+            mgr.update(&gpu.device, &gpu.queue);
+            px = center_pixel(&gpu, &mgr, idx);
+            if px[3] < 255 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(16));
+        }
+        assert!(
+            px[3] < 255,
+            "transparent page did not yield alpha<255 (viewport still opaque); got {px:?}"
         );
     }
 }

--- a/src/internal/html/servo_backend.rs
+++ b/src/internal/html/servo_backend.rs
@@ -22,13 +22,15 @@ use std::time::Duration;
 use anyhow::{anyhow, Result};
 use euclid::Box2D;
 use servo::{
-    LoadStatus, RenderingContext, Servo, ServoBuilder, SoftwareRenderingContext, WebView,
-    WebViewBuilder, WebViewDelegate,
+    DevicePoint, DeviceVector2D, ImeEvent, InputEvent, KeyboardEvent, LoadStatus, MouseButton,
+    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, Preferences, RenderingContext, Scroll,
+    Servo, ServoBuilder, SoftwareRenderingContext, WebView, WebViewBuilder, WebViewDelegate,
+    WebViewPoint, WebViewVector, WheelDelta, WheelEvent, WheelMode,
 };
 use url::Url;
 use winit::dpi::PhysicalSize;
 
-use super::{FrameSlot, HtmlFrame, HtmlId};
+use super::{FrameSlot, HtmlFrame, HtmlId, HtmlInputEvent};
 
 /// Cadence when at least one WebView is loading/animating/has a new frame.
 const ACTIVE_PARK: Duration = Duration::from_millis(8);
@@ -71,6 +73,13 @@ enum HtmlCommand {
         id: HtmlId,
         url: String,
     },
+    Reload {
+        id: HtmlId,
+    },
+    Input {
+        id: HtmlId,
+        event: HtmlInputEvent,
+    },
     Stop {
         id: HtmlId,
     },
@@ -110,6 +119,17 @@ impl ServoEngine {
             id,
             url: url.to_string(),
         });
+        self.unpark();
+    }
+
+    pub fn reload(&self, id: HtmlId) {
+        let _ = self.sender.send(HtmlCommand::Reload { id });
+        self.unpark();
+    }
+
+    /// Forward an interactive-mode input event to the WebView `id`.
+    pub fn send_input(&self, id: HtmlId, event: HtmlInputEvent) {
+        let _ = self.sender.send(HtmlCommand::Input { id, event });
         self.unpark();
     }
 
@@ -213,12 +233,82 @@ fn create_entry(
     })
 }
 
+/// A WebView point in device pixels.
+fn device_point(x: f32, y: f32) -> WebViewPoint {
+    WebViewPoint::Device(DevicePoint::new(x, y))
+}
+
+/// Translate a `Send` [`HtmlInputEvent`] into the corresponding Servo input and
+/// apply it to `entry`'s WebView, flagging it for a fresh paint. The WebView is
+/// only ever touched here, on its owning thread.
+fn apply_input(entry: &Entry, event: HtmlInputEvent) {
+    let wv = &entry.webview;
+    match event {
+        HtmlInputEvent::MouseMove { x, y } => {
+            let _ = wv.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
+                device_point(x, y),
+            )));
+        }
+        HtmlInputEvent::MouseButton {
+            x,
+            y,
+            button,
+            pressed,
+        } => {
+            let action = if pressed {
+                MouseButtonAction::Down
+            } else {
+                MouseButtonAction::Up
+            };
+            let event =
+                MouseButtonEvent::new(action, MouseButton::from(button as u64), device_point(x, y));
+            let _ = wv.notify_input_event(InputEvent::MouseButton(event));
+        }
+        HtmlInputEvent::Wheel { x, y, dx, dy } => {
+            let delta = WheelDelta {
+                x: dx,
+                y: dy,
+                z: 0.0,
+                mode: WheelMode::DeltaPixel,
+            };
+            let _ = wv.notify_input_event(InputEvent::Wheel(WheelEvent::new(
+                delta,
+                device_point(x, y),
+            )));
+        }
+        HtmlInputEvent::Scroll { x, y, dx, dy } => {
+            let vector = WebViewVector::Device(DeviceVector2D::new(dx as f32, dy as f32));
+            wv.notify_scroll_event(Scroll::Delta(vector), device_point(x, y));
+        }
+        HtmlInputEvent::Key(kt) => {
+            let _ = wv.notify_input_event(InputEvent::Keyboard(KeyboardEvent::new(kt)));
+        }
+        HtmlInputEvent::Ime(comp) => {
+            let _ = wv.notify_input_event(InputEvent::Ime(ImeEvent::Composition(comp)));
+        }
+        HtmlInputEvent::ImeDismissed => {
+            let _ = wv.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
+        }
+        HtmlInputEvent::Focus(true) => wv.focus(),
+        HtmlInputEvent::Focus(false) => wv.blur(),
+    }
+    entry.ready.set(true);
+}
+
 /// The owning servo thread: builds Servo, applies commands, and pumps WebViews,
 /// publishing the latest frame for each into its shared slot (latest-wins).
 fn run_servo_thread(rx: Receiver<HtmlCommand>) {
     let waker = UnparkWaker(thread::current());
+    // Clear the Servo viewport to fully transparent instead of the default opaque
+    // white, so pages with a transparent html/body yield alpha=0 pixels in
+    // read_to_image. This is Blocker 1 for per-deck transparency (/spec/html-source.md §2).
+    let preferences = Preferences {
+        shell_background_color_rgba: [0.0, 0.0, 0.0, 0.0],
+        ..Preferences::default()
+    };
     let servo = ServoBuilder::default()
         .event_loop_waker(Box::new(waker))
+        .preferences(preferences)
         .build();
     let mut entries: HashMap<HtmlId, Entry> = HashMap::new();
 
@@ -248,6 +338,17 @@ fn run_servo_thread(rx: Receiver<HtmlCommand>) {
                             }
                             Err(e) => log::error!("HTML navigate: invalid URL '{url}': {e}"),
                         }
+                    }
+                }
+                Ok(HtmlCommand::Reload { id }) => {
+                    if let Some(entry) = entries.get_mut(&id) {
+                        entry.webview.reload();
+                        entry.ready.set(true);
+                    }
+                }
+                Ok(HtmlCommand::Input { id, event }) => {
+                    if let Some(entry) = entries.get(&id) {
+                        apply_input(entry, event);
                     }
                 }
                 Ok(HtmlCommand::Stop { id }) => {

--- a/src/internal/mixer/render.rs
+++ b/src/internal/mixer/render.rs
@@ -535,15 +535,21 @@ impl Mixer {
 
         // Fallback: opacity-based crossfade
         //
-        // For 2-channel mode the first channel is blitted onto a cleared-to-black
-        // target using ALPHA_BLENDING.  The hardware blend applies SrcAlpha to the
-        // RGB output, so if the blit shader also multiplies alpha by opacity, the
-        // effective weight becomes opacity² (double-application).
+        // For 2-channel mode the first channel is blitted onto a cleared-to-
+        // transparent target using ALPHA_BLENDING.  The hardware blend applies
+        // SrcAlpha to the RGB output, so if the blit shader also multiplies alpha
+        // by opacity, the effective weight becomes opacity² (double-application).
         //
         // To avoid this, the first channel is always blitted at full opacity and
         // the crossfader value is used solely as the second channel's composite
         // opacity.  The composite shader performs `mix(dst, src, src_a)`, which
         // yields the correct linear crossfade: (1-cf)·A + cf·B.
+        //
+        // The clear is TRANSPARENT (not BLACK) so the program output carries the
+        // channels' alpha through to alpha-capable outputs. Because the clear RGB
+        // is zero either way, RGB is byte-identical to the old over-black result
+        // (the program becomes premultiplied-alpha); opaque content (alpha=1) and
+        // the over-black display path are unchanged. See /spec/html-source.md §2.
         let opacities = self.compositing_opacities();
 
         // Batch channel compositing into command buffers for deferred submission.
@@ -581,7 +587,7 @@ impl Mixer {
                             view: &self.composite_view,
                             resolve_target: None,
                             ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                                 store: wgpu::StoreOp::Store,
                             },
                             depth_slice: None,

--- a/src/internal/persistence/mod.rs
+++ b/src/internal/persistence/mod.rs
@@ -466,6 +466,7 @@ pub fn snapshot_scene(mixer: &Mixer, render_width: u32, render_height: u32) -> S
                         source,
                         effects,
                         opacity: slot.opacity,
+                        transparent: slot.deck.transparent(),
                         blend_mode: slot.blend_mode.into(),
                         mute: slot.mute,
                         solo: slot.solo,
@@ -649,6 +650,7 @@ fn config_to_target(config: &OutputTargetConfig) -> OutputTarget {
             path: path.clone(),
             codec: match codec.as_str() {
                 "prores" | "ProRes" | "ProRes 422" => RecordingCodec::ProRes,
+                "prores_4444" | "ProRes4444" | "ProRes 4444" => RecordingCodec::ProRes4444,
                 "h265" | "H265" | "H.265 (HEVC)" => RecordingCodec::H265,
                 "av1" | "AV1" => RecordingCodec::AV1,
                 "hap" | "Hap" | "HAP" => RecordingCodec::Hap,
@@ -923,6 +925,7 @@ pub fn restore_scene(
                 Ok(deck) => {
                     let mut slot = crate::channel::DeckSlot::new(deck);
                     slot.opacity = deck_config.opacity;
+                    slot.deck.set_transparent(deck_config.transparent);
                     slot.blend_mode = deck_config.blend_mode.into();
                     slot.mute = deck_config.mute;
                     slot.solo = deck_config.solo;

--- a/src/internal/persistence/presets.rs
+++ b/src/internal/persistence/presets.rs
@@ -175,6 +175,7 @@ mod tests {
             },
             effects: vec![],
             opacity: 0.8,
+            transparent: false,
             blend_mode: BlendModeConfig::Normal,
             mute: false,
             solo: false,

--- a/src/internal/renderer/context.rs
+++ b/src/internal/renderer/context.rs
@@ -1226,6 +1226,8 @@ pub enum RecordingCodec {
     AV1,
     /// ProRes 422 (-c:v prores_ks -profile:v 2)
     ProRes,
+    /// ProRes 4444 with alpha (-c:v prores_ks -profile:v 4 -pix_fmt yuva444p10le)
+    ProRes4444,
     /// HAP (-c:v hap -format hap)
     Hap,
     /// HAP Alpha (-c:v hap -format hap_alpha)
@@ -1241,6 +1243,7 @@ impl std::fmt::Display for RecordingCodec {
             RecordingCodec::H265 => write!(f, "H.265 (HEVC)"),
             RecordingCodec::AV1 => write!(f, "AV1"),
             RecordingCodec::ProRes => write!(f, "ProRes 422"),
+            RecordingCodec::ProRes4444 => write!(f, "ProRes 4444"),
             RecordingCodec::Hap => write!(f, "HAP"),
             RecordingCodec::HapAlpha => write!(f, "HAP Alpha"),
             RecordingCodec::HapQ => write!(f, "HAP Q"),

--- a/src/internal/renderer/subprocess.rs
+++ b/src/internal/renderer/subprocess.rs
@@ -385,23 +385,43 @@ impl FfmpegSubprocess {
             Some(p) => (&p.in_args, &p.out_args),
             None => (&empty, &empty),
         };
-        let (codec_args, needs_yuv420p): (Vec<&str>, bool) = match codec {
+        // (codec args, needs yuv420p output, alpha-capable). Alpha-capable codecs
+        // get an `unpremultiply` filter because the program output is
+        // premultiplied-alpha (see /spec/html-source.md §2); for fully opaque
+        // pixels unpremultiply is a no-op, so existing opaque recordings are
+        // unchanged.
+        let (codec_args, needs_yuv420p, alpha): (Vec<&str>, bool, bool) = match codec {
             RecordingCodec::H264 => (
                 vec!["-c:v", "libx264", "-preset", "ultrafast", "-crf", "18"],
                 true,
+                false,
             ),
             RecordingCodec::H265 => (
                 vec!["-c:v", "libx265", "-preset", "ultrafast", "-crf", "20"],
                 true,
+                false,
             ),
             RecordingCodec::AV1 => (
                 vec!["-c:v", "libsvtav1", "-preset", "10", "-crf", "28"],
                 true,
+                false,
             ),
-            RecordingCodec::ProRes => (vec!["-c:v", "prores_ks", "-profile:v", "2"], true),
-            RecordingCodec::Hap => (vec!["-c:v", "hap", "-format", "hap"], false),
-            RecordingCodec::HapAlpha => (vec!["-c:v", "hap", "-format", "hap_alpha"], false),
-            RecordingCodec::HapQ => (vec!["-c:v", "hap", "-format", "hap_q"], false),
+            RecordingCodec::ProRes => (vec!["-c:v", "prores_ks", "-profile:v", "2"], true, false),
+            RecordingCodec::ProRes4444 => (
+                vec![
+                    "-c:v",
+                    "prores_ks",
+                    "-profile:v",
+                    "4",
+                    "-pix_fmt",
+                    "yuva444p10le",
+                ],
+                false,
+                true,
+            ),
+            RecordingCodec::Hap => (vec!["-c:v", "hap", "-format", "hap"], false, false),
+            RecordingCodec::HapAlpha => (vec!["-c:v", "hap", "-format", "hap_alpha"], false, true),
+            RecordingCodec::HapQ => (vec!["-c:v", "hap", "-format", "hap_q"], false, true),
         };
 
         let mut cmd = Command::new("ffmpeg");
@@ -411,8 +431,11 @@ impl FfmpegSubprocess {
             .args(["-s", &format!("{}x{}", width, height)])
             .args(["-r", &fps.to_string()])
             .args(["-i", "-"])
-            .args(a_in)
-            .args(&codec_args);
+            .args(a_in);
+        if alpha {
+            cmd.args(["-vf", "unpremultiply=inplace=1"]);
+        }
+        cmd.args(&codec_args);
         if needs_yuv420p {
             cmd.args(["-pix_fmt", "yuv420p"]);
         }
@@ -1155,6 +1178,7 @@ mod tests {
         assert_eq!(format!("{}", RecordingCodec::H265), "H.265 (HEVC)");
         assert_eq!(format!("{}", RecordingCodec::AV1), "AV1");
         assert_eq!(format!("{}", RecordingCodec::ProRes), "ProRes 422");
+        assert_eq!(format!("{}", RecordingCodec::ProRes4444), "ProRes 4444");
         assert_eq!(format!("{}", RecordingCodec::Hap), "HAP");
         assert_eq!(format!("{}", RecordingCodec::HapAlpha), "HAP Alpha");
         assert_eq!(format!("{}", RecordingCodec::HapQ), "HAP Q");

--- a/src/internal/scene/mod.rs
+++ b/src/internal/scene/mod.rs
@@ -125,6 +125,11 @@ pub struct DeckConfig {
     #[serde(default = "default_opacity")]
     pub opacity: f32,
 
+    /// Transparent compositing: preserve source alpha instead of flattening over
+    /// black. Defaults to false for backward compatibility with existing scenes.
+    #[serde(default)]
+    pub transparent: bool,
+
     /// Blend mode for compositing
     #[serde(default)]
     pub blend_mode: BlendModeConfig,
@@ -798,6 +803,7 @@ mod tests {
                     },
                     effects: vec![],
                     opacity: 0.8,
+                    transparent: false,
                     blend_mode: BlendModeConfig::Add,
                     mute: false,
                     solo: false,
@@ -955,6 +961,19 @@ mod tests {
         assert!(!deck.mute);
         assert!(!deck.solo);
         assert_eq!(deck.z_index, 0);
+        // Backward compatibility: scenes saved before the transparency feature
+        // omit `transparent` and must load as opaque (false). See html-source.md §2.
+        assert!(!deck.transparent);
+    }
+
+    #[test]
+    fn deck_config_transparent_roundtrip() {
+        let json = r#"{"source": {"type": "SolidColor", "color": [1,0,0,1]}, "transparent": true}"#;
+        let deck: DeckConfig = serde_json::from_str(json).unwrap();
+        assert!(deck.transparent);
+        let reser = serde_json::to_string(&deck).unwrap();
+        let back: DeckConfig = serde_json::from_str(&reser).unwrap();
+        assert!(back.transparent);
     }
 
     // ── BlendModeConfig conversion ───────────────────────────────────
@@ -1091,6 +1110,7 @@ mod tests {
                     },
                     effects: vec![],
                     opacity: 0.5,
+                    transparent: false,
                     blend_mode: BlendModeConfig::Normal,
                     mute: false,
                     solo: false,
@@ -1180,6 +1200,7 @@ mod tests {
             },
             effects: vec![],
             opacity: -0.5,
+            transparent: false,
             blend_mode: BlendModeConfig::Normal,
             mute: false,
             solo: false,

--- a/src/usecases/api/projection.rs
+++ b/src/usecases/api/projection.rs
@@ -157,14 +157,17 @@ pub(crate) mod tests {
                     opacity: 1.0,
                     blend_mode: BlendMode::Normal,
                     decks: vec![DeckSnapshot {
+                        is_html_interactive: false,
                         idx: 0,
                         uuid: "dk-001".into(),
                         name: "Sine".into(),
+                        is_html: false,
                         opacity: 1.0,
                         effective_opacity: 1.0,
                         blend_mode: BlendMode::Normal,
                         solo: false,
                         mute: false,
+                        transparent: false,
                         scaling_mode: None,
                         generator: ShaderParamsSnapshot {
                             shader_name: "Sine".into(),

--- a/src/usecases/api/routes/decks.rs
+++ b/src/usecases/api/routes/decks.rs
@@ -358,6 +358,25 @@ pub async fn set_render_fps(
     }
 }
 
+#[utoipa::path(put, path = "/api/channels/{ch_idx}/decks/{deck_idx}/transparent", params(("ch_idx" = usize, Path, description = "Channel index"), ("deck_idx" = usize, Path, description = "Deck index within the channel")), request_body = DeckBoolBody, responses((status = 200, body = CommandResult)), tag = "Decks")]
+pub async fn set_transparent(
+    State(state): State<SharedState>,
+    Path((ch_idx, deck_idx)): Path<(usize, usize)>,
+    Json(body): Json<DeckBoolBody>,
+) -> impl IntoResponse {
+    match state
+        .send_command(EngineCommand::SetDeckTransparent {
+            channel_idx: ch_idx,
+            deck_idx,
+            transparent: body.value,
+        })
+        .await
+    {
+        Ok(result) => command_response(result),
+        Err(msg) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, msg).into_response(),
+    }
+}
+
 #[utoipa::path(put, path = "/api/channels/{ch_idx}/decks/{deck_idx}/scaling-mode", params(("ch_idx" = usize, Path, description = "Channel index"), ("deck_idx" = usize, Path, description = "Deck index within the channel")), request_body = DeckScalingModeBody, responses((status = 200, body = CommandResult)), tag = "Decks")]
 pub async fn set_scaling_mode(
     State(state): State<SharedState>,
@@ -848,6 +867,50 @@ pub async fn add_html_deck(
         })
         .await
     {
+        Ok(r) => command_response(r),
+        Err(m) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, m).into_response(),
+    }
+}
+
+#[utoipa::path(post, path = "/api/channels/{ch_idx}/decks/{deck_idx}/html/reload", params(("ch_idx" = usize, Path, description = "Channel index"), ("deck_idx" = usize, Path, description = "Deck index within the channel")), responses((status = 200, body = CommandResult)), tag = "Decks")]
+pub async fn reload_html_deck(
+    State(s): State<SharedState>,
+    Path((ch_idx, deck_idx)): Path<(usize, usize)>,
+) -> impl IntoResponse {
+    match s
+        .send_command(EngineCommand::ReloadHtmlDeck {
+            channel_idx: ch_idx,
+            deck_idx,
+        })
+        .await
+    {
+        Ok(r) => command_response(r),
+        Err(m) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, m).into_response(),
+    }
+}
+
+/// Body for opening/closing the interactive window of an HTML deck.
+#[derive(Deserialize, ToSchema)]
+pub struct HtmlInteractiveBody {
+    /// True to open the interactive window, false to close it.
+    pub open: bool,
+}
+
+#[utoipa::path(post, path = "/api/channels/{ch_idx}/decks/{deck_idx}/html/interactive", params(("ch_idx" = usize, Path, description = "Channel index"), ("deck_idx" = usize, Path, description = "Deck index within the channel")), request_body = HtmlInteractiveBody, responses((status = 200, body = CommandResult)), tag = "Decks")]
+pub async fn set_html_interactive(
+    State(s): State<SharedState>,
+    Path((ch_idx, deck_idx)): Path<(usize, usize)>,
+    Json(body): Json<HtmlInteractiveBody>,
+) -> impl IntoResponse {
+    let cmd = if body.open {
+        EngineCommand::OpenHtmlInteractive {
+            channel_idx: ch_idx,
+            deck_idx,
+        }
+    } else {
+        EngineCommand::CloseHtmlInteractive
+    };
+    match s.send_command(cmd).await {
         Ok(r) => command_response(r),
         Err(m) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, m).into_response(),
     }

--- a/src/usecases/api/runner.rs
+++ b/src/usecases/api/runner.rs
@@ -51,11 +51,12 @@ use utoipa_swagger_ui::SwaggerUi;
         routes::decks::set_solo, routes::decks::set_mute,
         routes::decks::add_image_deck, routes::decks::add_video_deck,
         routes::decks::add_solid_color_deck, routes::decks::add_camera_deck,
-        routes::decks::move_deck, routes::decks::reorder_deck, routes::decks::set_scaling_mode, routes::decks::set_render_fps,
+        routes::decks::move_deck, routes::decks::reorder_deck, routes::decks::set_scaling_mode, routes::decks::set_transparent, routes::decks::set_render_fps,
         routes::decks::set_transition, routes::decks::set_param,
         routes::decks::add_ndi_deck, routes::decks::add_syphon_deck,
         routes::decks::add_srt_deck, routes::decks::add_hls_deck, routes::decks::add_dash_deck, routes::decks::add_rtmp_deck,
-        routes::decks::add_html_deck,
+        routes::decks::add_html_deck, routes::decks::reload_html_deck,
+        routes::decks::set_html_interactive,
         routes::decks::reset_generator_params,
         // Video
         routes::decks::video_toggle_play, routes::decks::video_seek,
@@ -307,6 +308,10 @@ pub fn build_router(shared: SharedState) -> Router {
             axum::routing::put(routes::decks::set_scaling_mode),
         )
         .route(
+            "/api/channels/{ch_idx}/decks/{deck_idx}/transparent",
+            axum::routing::put(routes::decks::set_transparent),
+        )
+        .route(
             "/api/channels/{ch_idx}/decks/{deck_idx}/render-fps",
             axum::routing::put(routes::decks::set_render_fps),
         )
@@ -518,6 +523,14 @@ pub fn build_router(shared: SharedState) -> Router {
         .route(
             "/api/channels/{ch}/decks/html",
             axum::routing::post(routes::decks::add_html_deck),
+        )
+        .route(
+            "/api/channels/{ch_idx}/decks/{deck_idx}/html/reload",
+            axum::routing::post(routes::decks::reload_html_deck),
+        )
+        .route(
+            "/api/channels/{ch_idx}/decks/{deck_idx}/html/interactive",
+            axum::routing::post(routes::decks::set_html_interactive),
         )
         // ── Write: Modulation Updates ────────────────────────────
         .route(

--- a/src/usecases/ui/mod.rs
+++ b/src/usecases/ui/mod.rs
@@ -585,12 +585,18 @@ pub struct DeckUIInfo {
     pub deck_idx: usize,
     pub uuid: String,
     pub name: String,
+    /// True when this deck's source is an HTML/Servo instance.
+    pub is_html: bool,
+    /// True when the interactive window is currently open for this deck.
+    pub is_html_interactive: bool,
     pub opacity: f32,
     /// Effective opacity accounting for auto-transition state (for visual feedback only)
     pub effective_opacity: f32,
     pub blend_mode: BlendMode,
     pub solo: bool,
     pub mute: bool,
+    /// True when this deck preserves source alpha (transparent compositing).
+    pub transparent: bool,
     pub scaling_mode: Option<ScalingMode>,
     pub generator: ShaderParamsUI,
     pub effects: Vec<EffectInfo>,
@@ -1214,6 +1220,8 @@ pub struct UIActions {
     pub deck_updates: Vec<(usize, usize, f32, BlendMode, bool, bool)>,
     /// (ch_idx, deck_idx, scaling_mode) — change scaling mode for an image deck
     pub scaling_mode_updates: Vec<(usize, usize, ScalingMode)>,
+    /// (ch_idx, deck_idx, transparent) — toggle transparent compositing for a deck
+    pub transparent_updates: Vec<(usize, usize, bool)>,
     /// (ch_idx, deck_idx, render_fps) — change render FPS for a deck
     pub render_fps_updates: Vec<(usize, usize, DeckRenderFps)>,
     /// (ch_idx, deck_idx, filter_registry_idx) — add effect to deck
@@ -1353,6 +1361,11 @@ pub struct UIActions {
     pub rtmp_library_remove: Option<String>,
     /// (ch_idx, url) — add an HTML source as a new deck to channel
     pub html_to_add: Option<(usize, String)>,
+    /// (ch_idx, deck_idx) — reload an existing HTML deck (re-fetch its URL)
+    pub html_to_reload: Vec<(usize, usize)>,
+    /// (ch_idx, deck_idx, open) — open (true) or close (false) the interactive
+    /// window for an HTML deck.
+    pub html_set_interactive: Vec<(usize, usize, bool)>,
     /// HTML URL to add to library
     pub html_library_add: Option<String>,
     /// HTML URL to remove from library
@@ -1531,6 +1544,7 @@ impl UIActions {
             deck_to_remove: None,
             deck_updates: Vec::new(),
             scaling_mode_updates: Vec::new(),
+            transparent_updates: Vec::new(),
             render_fps_updates: Vec::new(),
             effect_to_add: None,
             effect_to_remove: None,
@@ -1604,6 +1618,8 @@ impl UIActions {
             rtmp_library_add: None,
             rtmp_library_remove: None,
             html_to_add: None,
+            html_to_reload: Vec::new(),
+            html_set_interactive: Vec::new(),
             html_library_add: None,
             html_library_remove: None,
             audio_rescan: false,
@@ -1633,6 +1649,7 @@ impl UIActions {
             || self.deck_to_remove.is_some()
             || !self.deck_updates.is_empty()
             || !self.scaling_mode_updates.is_empty()
+            || !self.transparent_updates.is_empty()
             || !self.render_fps_updates.is_empty()
             || !self.param_updates.is_empty()
             || !self.modulation_actions.is_empty()
@@ -1749,11 +1766,14 @@ impl UIData {
             deck_idx: 0,
             uuid: "a0000001".to_string(),
             name: "test_generator_a".to_string(),
+            is_html: false,
+            is_html_interactive: false,
             opacity: 1.0,
             effective_opacity: 1.0,
             blend_mode: BlendMode::Normal,
             solo: false,
             mute: false,
+            transparent: false,
             scaling_mode: Some(ScalingMode::Fit),
             generator: ShaderParamsUI {
                 shader_name: "test_generator_a".to_string(),
@@ -1792,11 +1812,14 @@ impl UIData {
             deck_idx: 1,
             uuid: "a0000002".to_string(),
             name: "test_generator_b".to_string(),
+            is_html: false,
+            is_html_interactive: false,
             opacity: 0.8,
             effective_opacity: 0.8,
             blend_mode: BlendMode::Normal,
             solo: false,
             mute: false,
+            transparent: false,
             scaling_mode: Some(ScalingMode::Fit),
             generator: ShaderParamsUI {
                 shader_name: "test_generator_b".to_string(),
@@ -1833,11 +1856,14 @@ impl UIData {
             deck_idx: 0,
             uuid: "b0000001".to_string(),
             name: "test_generator_c".to_string(),
+            is_html: false,
+            is_html_interactive: false,
             opacity: 1.0,
             effective_opacity: 1.0,
             blend_mode: BlendMode::Normal,
             solo: false,
             mute: false,
+            transparent: false,
             scaling_mode: Some(ScalingMode::Fit),
             generator: ShaderParamsUI {
                 shader_name: "test_generator_c".to_string(),
@@ -1856,11 +1882,14 @@ impl UIData {
             deck_idx: 1,
             uuid: "b0000002".to_string(),
             name: "test_generator_d".to_string(),
+            is_html: false,
+            is_html_interactive: false,
             opacity: 1.0,
             effective_opacity: 1.0,
             blend_mode: BlendMode::Normal,
             solo: false,
             mute: false,
+            transparent: false,
             scaling_mode: Some(ScalingMode::Fit),
             generator: ShaderParamsUI {
                 shader_name: "test_generator_d".to_string(),

--- a/src/usecases/ui/panels/deck_detail.rs
+++ b/src/usecases/ui/panels/deck_detail.rs
@@ -189,6 +189,70 @@ pub(super) fn render_selected_deck_detail(
                 ui.separator();
             }
 
+            // Column: HTML source controls (only for HTML decks)
+            if deck.is_html {
+                egui::Frame::default()
+                    .inner_margin(6.0)
+                    .corner_radius(4.0)
+                    .fill(ui.visuals().faint_bg_color)
+                    .show(ui, |ui| {
+                        ui.set_min_width(140.0);
+                        ui.set_max_width(200.0);
+                        ui.with_layout(egui::Layout::top_down(egui::Align::LEFT), |ui| {
+                            ui.label(egui::RichText::new("🌐 HTML").strong());
+                            let reload_resp = ui.button("⟳ Reload");
+                            if reload_resp.clicked() {
+                                actions.html_to_reload.push((ch_idx, deck_idx));
+                            }
+                            learn_overlay(
+                                ui,
+                                reload_resp.rect,
+                                format!("deck/{}/html/reload", deck.uuid),
+                                data,
+                                actions,
+                            );
+                            let interactive_label = if deck.is_html_interactive {
+                                "🖱 Exit Interactive"
+                            } else {
+                                "🖱 Interactive"
+                            };
+                            let interactive_resp = ui.button(interactive_label);
+                            if interactive_resp.clicked() {
+                                actions.html_set_interactive.push((
+                                    ch_idx,
+                                    deck_idx,
+                                    !deck.is_html_interactive,
+                                ));
+                            }
+                            learn_overlay(
+                                ui,
+                                interactive_resp.rect,
+                                format!("deck/{}/html/interactive", deck.uuid),
+                                data,
+                                actions,
+                            );
+                            let mut transparent = deck.transparent;
+                            let transparent_resp =
+                                ui.checkbox(&mut transparent, "Transparent BG");
+                            if transparent_resp.changed() {
+                                actions.transparent_updates.push((
+                                    ch_idx,
+                                    deck_idx,
+                                    transparent,
+                                ));
+                            }
+                            learn_overlay(
+                                ui,
+                                transparent_resp.rect,
+                                format!("deck/{}/transparent", deck.uuid),
+                                data,
+                                actions,
+                            );
+                        });
+                    });
+                ui.separator();
+            }
+
             // Column: Video playback controls (only for video decks)
             if let Some(ref vp) = deck.video_playback {
                 egui::Frame::default()

--- a/src/usecases/ui/panels/outputs.rs
+++ b/src/usecases/ui/panels/outputs.rs
@@ -276,6 +276,7 @@ fn render_headless_controls(
                             RecordingCodec::H265,
                             RecordingCodec::AV1,
                             RecordingCodec::ProRes,
+                            RecordingCodec::ProRes4444,
                             RecordingCodec::Hap,
                             RecordingCodec::HapAlpha,
                             RecordingCodec::HapQ,

--- a/src/usecases/ui/runner.rs
+++ b/src/usecases/ui/runner.rs
@@ -361,6 +361,11 @@ impl ApplicationHandler for UIRunner {
                 _ => {}
             }
         } else {
+            // Interactive HTML window: forward input to the WebView and consume.
+            #[cfg(feature = "html")]
+            if varda.handle_interactive_event(window_id, &event) {
+                return;
+            }
             match event {
                 WindowEvent::CloseRequested => {
                     if let Some(name) = varda.close_output_window_by_id(window_id) {
@@ -760,6 +765,8 @@ impl UIRunner {
         // Create pending output windows (API-driven in headless)
         varda.create_pending_outputs(event_loop);
         varda.refresh_monitors(event_loop);
+        #[cfg(feature = "html")]
+        varda.create_pending_interactive(event_loop);
 
         // GPU render (mixer compositing)
         varda.render_mixer_frame();
@@ -780,6 +787,8 @@ impl UIRunner {
 
         // Render output windows + publish state
         varda.render_outputs();
+        #[cfg(feature = "html")]
+        varda.render_interactive();
         self.publish_counter += 1;
         if self.publish_counter.is_multiple_of(10) {
             varda.publish_state();
@@ -811,6 +820,8 @@ impl UIRunner {
             };
             varda.create_pending_outputs(event_loop);
             varda.refresh_monitors(event_loop);
+            #[cfg(feature = "html")]
+            varda.create_pending_interactive(event_loop);
         }
 
         // 3b. Render dome preview if open (either dome_preview_open or dome_mode_active)
@@ -1463,6 +1474,8 @@ impl UIRunner {
             let c_roll = self.layout.dome_geometry.content_roll_degrees.to_radians();
             varda.set_domemaster_content_rotation(c_az, c_el, c_roll);
             varda.render_outputs();
+            #[cfg(feature = "html")]
+            varda.render_interactive();
             self.publish_counter += 1;
             if self.publish_counter.is_multiple_of(10) {
                 varda.publish_state();


### PR DESCRIPTION
https://github.com/im-knots/varda/issues/63#issuecomment-4821591782

add servo interactive mode for http source decks. 
add refresh/reload button for http source decks (standard browser refresh)
add toggle for how varda handles transparent backgrounds in http soruces
