### PR TITLE
#72: render selected deck/channel previews, relax culling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The **usecases layer** is the only place that touches egui or windowed rendering
 
 This means you can drive the same engine from the GUI, the HTTP API, or a test harness without changing engine code.
 
-External I/O (NDI, SRT, HLS/DASH, RTMP, and recording) uses non-blocking subprocess architecture with bounded channels to keep the render thread fast. GPU work is batched into minimal command buffer submissions. The render pass culls zero-opacity decks and channels so you only pay for what's live.
+External I/O (NDI, SRT, HLS/DASH, RTMP, and recording) uses non-blocking subprocess architecture with bounded channels to keep the render thread fast. GPU work is batched into minimal command buffer submissions. The render pass culls zero-opacity decks and channels so you only pay for what's live — with one exception: the channel you currently have selected is force-rendered even when off-air, so you can cue and build a composition on it and watch its preview update live without it touching the output.
 
 ### Entity Identity & Address Scheme
 

--- a/benches/compositing.rs
+++ b/benches/compositing.rs
@@ -79,7 +79,7 @@ fn time_render_us(ctx: &GpuContext, mixer: &mut Mixer, samples: usize) -> u128 {
     let analyzer_values = AnalyzerValues::default();
     for _ in 0..3 {
         mixer
-            .render(ctx, &audio, &audio_values, &analyzer_values, 60)
+            .render(ctx, &audio, &audio_values, &analyzer_values, 60, &[])
             .expect("warmup");
         poll(ctx);
     }
@@ -87,7 +87,7 @@ fn time_render_us(ctx: &GpuContext, mixer: &mut Mixer, samples: usize) -> u128 {
     for _ in 0..samples {
         let t0 = Instant::now();
         mixer
-            .render(ctx, &audio, &audio_values, &analyzer_values, 60)
+            .render(ctx, &audio, &audio_values, &analyzer_values, 60, &[])
             .expect("render");
         poll(ctx);
         times.push(t0.elapsed().as_micros());
@@ -134,7 +134,7 @@ fn bench_channel_composite_solid(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("decks", n_decks), &n_decks, |b, _| {
             b.iter(|| {
                 mixer
-                    .render(&ctx, &audio, &audio_values, &analyzer_values, 60)
+                    .render(&ctx, &audio, &audio_values, &analyzer_values, 60, &[])
                     .expect("render");
                 poll(&ctx);
             });
@@ -164,7 +164,7 @@ fn bench_channel_composite_shader(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("decks", n_decks), &n_decks, |b, _| {
             b.iter(|| {
                 mixer
-                    .render(&ctx, &audio, &audio_values, &analyzer_values, 60)
+                    .render(&ctx, &audio, &audio_values, &analyzer_values, 60, &[])
                     .expect("render");
                 poll(&ctx);
             });
@@ -197,7 +197,7 @@ fn bench_mixer_crossfade(c: &mut Criterion) {
     group.bench_function("2ch_50pct", |b| {
         b.iter(|| {
             mixer
-                .render(&ctx, &audio, &audio_values, &analyzer_values, 60)
+                .render(&ctx, &audio, &audio_values, &analyzer_values, 60, &[])
                 .expect("render");
             poll(&ctx);
         });

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -245,6 +245,11 @@ pub struct VardaApp {
     // ── Frame pacing (global, runtime-mutable) ──────────
     target_fps: u32,
 
+    // ── Channel preview / cue (ephemeral, published by UI each frame) ──
+    // Channels force-rendered for off-air preview. Never persisted; affects the
+    // render gate only, never the compositor. See /spec/channel-preview.md.
+    preview_channels: Vec<usize>,
+
     // ── Pending MIDI-triggered actions (consumed by runner) ──
     pub(crate) midi_pending_undo: bool,
     pub(crate) midi_pending_redo: bool,
@@ -485,6 +490,7 @@ impl VardaApp {
             render_width: DEFAULT_RENDER_WIDTH,
             render_height: DEFAULT_RENDER_HEIGHT,
             target_fps: config.target_fps,
+            preview_channels: Vec::new(),
             midi_pending_undo: false,
             midi_pending_redo: false,
             midi_pending_save: false,
@@ -2203,6 +2209,13 @@ impl VardaApp {
         if let Some(dome) = &mut self.output.domemaster {
             dome.set_content_rotation(az, el, roll);
         }
+    }
+
+    /// Publish the set of channels to force-render for off-air preview.
+    /// Called by the runner each frame from the UI selection. Ephemeral — never
+    /// persisted; affects the render gate only. See /spec/channel-preview.md.
+    pub fn set_preview_channels(&mut self, channels: Vec<usize>) {
+        self.preview_channels = channels;
     }
 
     /// Number of loaded shaders.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -240,10 +240,13 @@ impl VardaApp {
             &n_ch_buf
         };
 
-        // Collect camera IDs needed by visible channels
+        // Collect camera IDs needed by visible channels. Cued (previewed)
+        // channels are included even at zero opacity so their live camera inputs
+        // keep advancing while off-air. See /spec/channel-preview.md.
         let mut needed_camera_ids = std::collections::HashSet::new();
         for (ch_idx, channel) in self.mixer.channels().iter().enumerate() {
-            if effective_opacities.get(ch_idx).copied().unwrap_or(0.0) <= 0.0 {
+            let visible = effective_opacities.get(ch_idx).copied().unwrap_or(0.0) > 0.0;
+            if !visible && !self.preview_channels.contains(&ch_idx) {
                 continue;
             }
             for slot in &channel.decks {
@@ -350,6 +353,7 @@ impl VardaApp {
             &audio_values,
             &analyzer_values,
             target_fps,
+            &self.preview_channels,
         ) {
             log::error!("Failed to render mixer: {}", e);
         }

--- a/src/internal/mixer/mod.rs
+++ b/src/internal/mixer/mod.rs
@@ -797,4 +797,70 @@ mod tests {
         let result = crossfader * opacity;
         assert!(result.is_nan());
     }
+
+    // ── Channel preview / cue tests (issue #72) ──────────────────────
+
+    fn add_solid_deck_to(mixer: &mut Mixer, gpu: &GpuContext, ch_idx: usize, color: [f32; 4]) {
+        let deck = crate::deck::Deck::new_solid_color(gpu, color, 64, 64).expect("solid deck");
+        mixer
+            .channel_mut(ch_idx)
+            .expect("channel exists")
+            .add_deck(deck);
+    }
+
+    fn render_once(mixer: &mut Mixer, gpu: &GpuContext, preview: &[usize]) {
+        let audio = crate::audio::AudioData::default();
+        let audio_values = crate::modulation::AudioValues::default();
+        let analyzer_values = crate::modulation::AnalyzerValues::default();
+        mixer
+            .render(gpu, &audio, &audio_values, &analyzer_values, 60, preview)
+            .expect("mixer render");
+    }
+
+    #[test]
+    fn culled_channel_not_rendered_with_empty_preview() {
+        // crossfader defaults to 0.0 → Ch 1 effective opacity is 0 → culled.
+        let gpu = headless_gpu();
+        let mut mixer = Mixer::new(&gpu, 64, 64).unwrap();
+        add_solid_deck_to(&mut mixer, &gpu, 1, [1.0, 0.0, 0.0, 1.0]);
+
+        render_once(&mut mixer, &gpu, &[]);
+
+        assert_eq!(
+            mixer.channel(1).unwrap().active_deck_count,
+            0,
+            "off-air channel must be culled when not cued"
+        );
+    }
+
+    #[test]
+    fn cued_channel_force_rendered_at_zero_opacity() {
+        let gpu = headless_gpu();
+        let mut mixer = Mixer::new(&gpu, 64, 64).unwrap();
+        add_solid_deck_to(&mut mixer, &gpu, 1, [1.0, 0.0, 0.0, 1.0]);
+
+        // Same effective-0 state, but Ch 1 is cued → force-rendered.
+        render_once(&mut mixer, &gpu, &[1]);
+
+        assert_eq!(
+            mixer.channel(1).unwrap().active_deck_count,
+            1,
+            "cued off-air channel must be force-rendered"
+        );
+    }
+
+    #[test]
+    fn empty_preview_matches_baseline() {
+        // The live channel (Ch 0, effective opacity 1.0) renders regardless of
+        // preview, guarding that the preview set only ever adds renders.
+        let gpu = headless_gpu();
+        let mut mixer = Mixer::new(&gpu, 64, 64).unwrap();
+        add_solid_deck_to(&mut mixer, &gpu, 0, [0.0, 1.0, 0.0, 1.0]);
+        add_solid_deck_to(&mut mixer, &gpu, 1, [1.0, 0.0, 0.0, 1.0]);
+
+        render_once(&mut mixer, &gpu, &[]);
+
+        assert_eq!(mixer.channel(0).unwrap().active_deck_count, 1);
+        assert_eq!(mixer.channel(1).unwrap().active_deck_count, 0);
+    }
 }

--- a/src/internal/mixer/render.rs
+++ b/src/internal/mixer/render.rs
@@ -38,6 +38,9 @@ impl Mixer {
 
     /// Render all channels and composite them via crossfader, then apply master effects.
     /// `target_fps` is used for adaptive deck render skipping budget calculation.
+    /// `preview_channels` are force-rendered even when culled by opacity, so their
+    /// off-air previews update live — without affecting the compositor (see
+    /// /spec/channel-preview.md).
     pub fn render(
         &mut self,
         context: &GpuContext,
@@ -45,6 +48,7 @@ impl Mixer {
         audio_values: &crate::modulation::AudioValues,
         analyzer_values: &crate::modulation::AnalyzerValues,
         target_fps: u32,
+        preview_channels: &[usize],
     ) -> Result<()> {
         let now = std::time::Instant::now();
         let dt = (now - self.last_render_time).as_secs_f32();
@@ -214,7 +218,10 @@ impl Mixer {
         let mut rendered_channels: u32 = 0;
         let mut per_ch_gpu_us: Vec<(String, u128)> = Vec::new();
         for (ch_idx, channel) in self.channels.iter_mut().enumerate() {
-            if effective_opacities.get(ch_idx).copied().unwrap_or(0.0) < 0.001 {
+            let culled = effective_opacities.get(ch_idx).copied().unwrap_or(0.0) < 0.001;
+            // Cued channels are force-rendered so their off-air previews update
+            // live; the compositor stays opacity-gated so they never leak to output.
+            if culled && !preview_channels.contains(&ch_idx) {
                 // Reset stats so culled channels don't show stale render metrics
                 channel.render_time_ms = 0.0;
                 channel.active_deck_count = 0;

--- a/src/usecases/ui/mod.rs
+++ b/src/usecases/ui/mod.rs
@@ -195,6 +195,21 @@ impl UILayoutState {
         }
     }
 
+    /// Channels to force-render for preview, derived from the current selection.
+    ///
+    /// Selecting a deck or a channel cues that channel so its off-air preview
+    /// updates live (see /spec/channel-preview.md). Master or no selection cues
+    /// nothing. Returned as a set (0 or 1 today) to leave room for multi-cue.
+    pub fn preview_channels(&self) -> Vec<usize> {
+        if let Some((ch, _)) = self.selected_deck {
+            vec![ch]
+        } else if let Some(ch) = self.selected_channel {
+            vec![ch]
+        } else {
+            Vec::new()
+        }
+    }
+
     /// Fix up selection indices after a channel is removed.
     pub fn fixup_channel_removal(&mut self, removed_ch: usize) {
         if let Some((sel_ch, _)) = self.selected_deck {
@@ -2145,5 +2160,55 @@ impl UIData {
             deck_presets: vec![],
             channel_presets: vec![],
         }
+    }
+}
+
+#[cfg(test)]
+mod preview_channel_tests {
+    use super::*;
+
+    #[test]
+    fn selected_deck_cues_its_channel() {
+        let layout = UILayoutState {
+            selected_deck: Some((1, 3)),
+            ..Default::default()
+        };
+        assert_eq!(layout.preview_channels(), vec![1]);
+    }
+
+    #[test]
+    fn selected_channel_cues_itself() {
+        let layout = UILayoutState {
+            selected_channel: Some(2),
+            ..Default::default()
+        };
+        assert_eq!(layout.preview_channels(), vec![2]);
+    }
+
+    #[test]
+    fn selected_master_cues_nothing() {
+        let layout = UILayoutState {
+            selected_master: true,
+            ..Default::default()
+        };
+        assert!(layout.preview_channels().is_empty());
+    }
+
+    #[test]
+    fn no_selection_cues_nothing() {
+        let layout = UILayoutState::default();
+        assert!(layout.preview_channels().is_empty());
+    }
+
+    #[test]
+    fn deck_takes_precedence_over_channel() {
+        // apply_selections keeps these mutually exclusive, but the derivation
+        // must be deterministic even if both happen to be set.
+        let layout = UILayoutState {
+            selected_deck: Some((0, 0)),
+            selected_channel: Some(1),
+            ..Default::default()
+        };
+        assert_eq!(layout.preview_channels(), vec![0]);
     }
 }

--- a/src/usecases/ui/runner.rs
+++ b/src/usecases/ui/runner.rs
@@ -768,6 +768,9 @@ impl UIRunner {
         #[cfg(feature = "html")]
         varda.create_pending_interactive(event_loop);
 
+        // Publish the cued channel(s) so off-air previews render live (issue #72).
+        varda.set_preview_channels(self.layout.preview_channels());
+
         // GPU render (mixer compositing)
         varda.render_mixer_frame();
 
@@ -1448,6 +1451,8 @@ impl UIRunner {
             let Some(varda) = self.varda.as_mut() else {
                 return;
             };
+            // Publish the cued channel(s) so off-air previews render live (issue #72).
+            varda.set_preview_channels(self.layout.preview_channels());
             varda.render_mixer_frame();
         }
         let mixer_us = t_mixer.elapsed().as_micros();


### PR DESCRIPTION
relaxed culling logic such that selected decks/channels will render their previews when mixer opacity is set to 0 so you can cue channel compositions. 
this has performance implications. you will be paying for the previews in the gpu render thread as if they were live. this is the desired behavior so previews are at full resolution/proper colors/ect.
