### PR TITLE
FEAT: use gpu max_texture_dimension_2d in UI rather than clamping max

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,16 @@ pub const DEFAULT_RENDER_WIDTH: u32 = 1920;
 /// Default render resolution for all decks and stage output (Full HD 1080p)
 pub const DEFAULT_RENDER_HEIGHT: u32 = 1080;
 
+/// Clamp a requested render resolution to what the GPU can allocate.
+///
+/// Varda imposes no artificial resolution cap; the only bound is the GPU's
+/// `max_texture_dimension_2d` (spec/resolution-and-scaling.md, "No Maximum
+/// Resolution"). Each dimension is independently clamped to `max_dim`. Zero is
+/// left untouched — callers reject it separately so this stays a pure clamp.
+pub(crate) fn clamp_resolution_to_gpu(width: u32, height: u32, max_dim: u32) -> (u32, u32) {
+    (width.min(max_dim), height.min(max_dim))
+}
+
 /// Session configuration derived from CLI flags + workspace defaults.
 /// CLI flags override persisted config for the session without modifying files.
 #[derive(Debug, Clone, clap::Parser)]
@@ -2278,13 +2288,26 @@ impl VardaApp {
         self.render_height
     }
 
+    /// Maximum render dimension (width or height) the GPU can allocate a
+    /// texture for. Varda imposes no artificial cap — this hardware limit is
+    /// the only bound on render resolution (see spec/resolution-and-scaling.md).
+    pub fn max_render_dimension(&self) -> u32 {
+        self.context.device.limits().max_texture_dimension_2d
+    }
+
     /// Change the master render resolution. Resizes all textures in the pipeline.
+    ///
+    /// Zero dimensions are rejected. Larger-than-hardware requests are clamped to
+    /// the GPU's `max_texture_dimension_2d` so both the UI and the HTTP API share
+    /// the same bound and neither can trigger a GPU allocation failure.
     pub fn set_render_resolution(&mut self, width: u32, height: u32) {
-        if width == self.render_width && height == self.render_height {
-            return;
-        }
         if width == 0 || height == 0 {
             log::warn!("Ignoring zero render resolution {}×{}", width, height);
+            return;
+        }
+        let max_dim = self.max_render_dimension();
+        let (width, height) = clamp_resolution_to_gpu(width, height, max_dim);
+        if width == self.render_width && height == self.render_height {
             return;
         }
         log::info!(
@@ -2727,6 +2750,21 @@ mod tests {
         .unwrap();
         app.process_commands();
         // Verify no crash — blend mode is GPU-level and verified through state
+    }
+
+    #[test]
+    fn clamp_resolution_leaves_in_range_untouched() {
+        // Within the GPU limit: returned unchanged.
+        assert_eq!(clamp_resolution_to_gpu(1920, 1080, 16384), (1920, 1080));
+        assert_eq!(clamp_resolution_to_gpu(16384, 16384, 16384), (16384, 16384));
+    }
+
+    #[test]
+    fn clamp_resolution_caps_each_dimension_to_gpu_max() {
+        // Beyond the GPU limit: each dimension clamped independently.
+        assert_eq!(clamp_resolution_to_gpu(20000, 12000, 16384), (16384, 12000));
+        assert_eq!(clamp_resolution_to_gpu(30000, 30000, 16384), (16384, 16384));
+        assert_eq!(clamp_resolution_to_gpu(1024, 99999, 8192), (1024, 8192));
     }
 
     #[test]

--- a/src/app/snapshot.rs
+++ b/src/app/snapshot.rs
@@ -1148,6 +1148,7 @@ pub(crate) fn build_ui_data(
         clock_manual_bpm: engine.clock.manual_bpm,
         render_width: app.render_width,
         render_height: app.render_height,
+        max_render_dimension: app.max_render_dimension(),
         target_fps: app.target_fps,
         // Populated by UIRunner after build (history/pending loads live on runner, not app)
         can_undo: false,

--- a/src/usecases/ui/mod.rs
+++ b/src/usecases/ui/mod.rs
@@ -894,6 +894,9 @@ pub struct UIData {
     pub render_width: u32,
     /// Current master render height
     pub render_height: u32,
+    /// GPU's maximum 2D texture dimension — the only bound on custom render
+    /// resolution (Varda imposes no artificial cap).
+    pub max_render_dimension: u32,
     /// Target FPS (0 = uncapped)
     pub target_fps: u32,
     /// Whether undo is available
@@ -2203,6 +2206,7 @@ impl UIData {
             clock_manual_bpm: None,
             render_width: 1920,
             render_height: 1080,
+            max_render_dimension: 16384,
             target_fps: 60,
             can_undo: false,
             can_redo: false,

--- a/src/usecases/ui/panels/mod.rs
+++ b/src/usecases/ui/panels/mod.rs
@@ -1366,17 +1366,20 @@ fn render_resolution_popover(ui: &mut egui::Ui, data: &UIData, actions: &mut UIA
     let mut custom_w: u32 = ui.data(|d| d.get_temp(custom_w_id)).unwrap_or(current_w);
     let mut custom_h: u32 = ui.data(|d| d.get_temp(custom_h_id)).unwrap_or(current_h);
 
+    // No artificial cap: the upper bound is the GPU's max texture dimension,
+    // matching what the engine/API accept (spec/resolution-and-scaling.md).
+    let max_dim = data.max_render_dimension;
     ui.horizontal(|ui| {
         ui.label("W:");
         ui.add(
             egui::DragValue::new(&mut custom_w)
-                .range(64..=7680)
+                .range(64..=max_dim)
                 .speed(16),
         );
         ui.label("H:");
         ui.add(
             egui::DragValue::new(&mut custom_h)
-                .range(64..=4320)
+                .range(64..=max_dim)
                 .speed(16),
         );
     });


### PR DESCRIPTION
API already used max_texture_dimension_2d, bringing UI into parity. 