### PR TITLE
DEBT: param router imrovements

### DIFF
--- a/docs/06-control-surfaces.md
+++ b/docs/06-control-surfaces.md
@@ -216,7 +216,7 @@ MIDI, OSC, and keyboard shortcuts all use the same parameter path format:
 | `deck/<uuid>/solo` | Deck solo toggle |
 | `deck/<uuid>/trigger` | Set deck opacity to 1.0 |
 | `deck/<uuid>/param/<name>` | Shader parameter |
-| `deck/<uuid>/effect/<k>/param/<name>` | Deck effect parameter |
+| `deck/<uuid>/effect/<effect_uuid>/param/<name>` | Deck effect parameter |
 | `deck/<uuid>/video/play` | Set video play state (playing when > 0.5) |
 | `deck/<uuid>/video/speed` | Video playback speed (0.0–1.0 → 0.1×–4.0×) |
 | `deck/<uuid>/video/seek` | Seek position (0.0–1.0 → start–end of clip) |
@@ -226,15 +226,16 @@ MIDI, OSC, and keyboard shortcuts all use the same parameter path format:
 | `deck/<uuid>/video/loop_mode` | Loop mode, fader-bucketed (Loop / Ping-Pong / One Shot / Hold Last) |
 | `deck/<uuid>/scaling_mode` | Source scaling, fader-bucketed (Fill / Fit / Stretch / Center) |
 | `ch/<uuid>/opacity` | Channel opacity |
-| `ch/<uuid>/effect/<k>/param/<name>` | Channel effect parameter |
-| `master/effect/<k>/param/<name>` | Master effect parameter |
-| `mod/<idx>/frequency` | LFO frequency |
-| `mod/<idx>/amplitude` | LFO amplitude |
+| `ch/<uuid>/effect/<effect_uuid>/param/<name>` | Channel effect parameter |
+| `master/effect/<effect_uuid>/param/<name>` | Master effect parameter |
+| `mod/<mod_uuid>/frequency` | LFO frequency |
+| `mod/<mod_uuid>/amplitude` | LFO amplitude |
+| `mod/<mod_uuid>/step/<n>` | Step-sequencer step value (step index is positional within the source) |
 | `action/undo` | Trigger undo |
 | `action/redo` | Trigger redo |
 | `action/save` | Trigger save |
 
-Entity UUIDs are stable 8-character hex strings that persist across moves, reorders, and scene save/restore.
+Entity UUIDs are stable 8-character hex strings that persist across moves, reorders, and scene save/restore. Decks, channels, effects, and modulation sources are all addressed by UUID — never by positional index — so a saved mapping keeps targeting the same entity after a chain or rack is reordered. LED feedback reads state back through the same UUID paths.
 
 The `video/*` and `scaling_mode` paths resolve only on the matching source type (video controls on video decks; `scaling_mode` on image, video, camera, and external-source decks). **Discrete (enum) controls** — `loop_mode` and `scaling_mode` — use **fader bucketing**: the 0.0–1.0 range is split into equal segments so a fader or knob sweeps through the options. **Seek and in/out points** scale the 0.0–1.0 value against the clip's duration, so one mapping works for clips of any length.
 

--- a/src/app/engine_impl.rs
+++ b/src/app/engine_impl.rs
@@ -504,27 +504,19 @@ impl MixerCommands for VardaApp {
     }
 
     fn set_param(&mut self, path: &str, value: ParamValue) {
-        // Convert ParamValue to f32 for the param router
-        let f_value = match value {
-            ParamValue::Float(v) => v,
-            ParamValue::Bool(b) => {
-                if b {
-                    1.0
-                } else {
-                    0.0
+        // Typed routing preserves Color/Point2D for shader/effect params; scalar
+        // paths flatten internally. OSC feedback stays a scalar f32.
+        let feedback_value = crate::param_router::param_value_to_norm_f32(&value);
+        match crate::param_router::apply_typed_param_by_path(&mut self.mixer, path, value) {
+            Ok(()) => {
+                // Broadcast to OSC feedback targets
+                if let Some(ref sender) = self.input.osc_feedback {
+                    if sender.has_targets() {
+                        sender.send_param(path, feedback_value);
+                    }
                 }
             }
-            ParamValue::Long(i) => i as f32,
-            ParamValue::Color(c) => c[0],
-            ParamValue::Point2D(p) => p[0],
-        };
-        if crate::param_router::apply_param_by_path(&mut self.mixer, path, f_value) {
-            // Broadcast to OSC feedback targets
-            if let Some(ref sender) = self.input.osc_feedback {
-                if sender.has_targets() {
-                    sender.send_param(path, f_value);
-                }
-            }
+            Err(e) => log::warn!("API set_param route failed ({path}): {e}"),
         }
     }
 }

--- a/src/app/inputs.rs
+++ b/src/app/inputs.rs
@@ -97,12 +97,15 @@ impl VardaApp {
                                     log::debug!("Unknown OSC action: {}", path);
                                 }
                             }
-                        } else if crate::param_router::apply_param_by_path(
-                            &mut self.mixer,
-                            path,
-                            value,
-                        ) {
-                            changed_params.push((path.clone(), value));
+                        } else {
+                            match crate::param_router::apply_param_by_path(
+                                &mut self.mixer,
+                                path,
+                                value,
+                            ) {
+                                Ok(()) => changed_params.push((path.clone(), value)),
+                                Err(e) => log::warn!("OSC param route failed ({path}): {e}"),
+                            }
                         }
                     }
                     crate::osc::OscInput::ClockBpm(bpm) => {
@@ -243,12 +246,15 @@ impl VardaApp {
                                 log::debug!("Unknown action path: {}", path);
                             }
                         }
-                    } else if crate::param_router::apply_param_by_path(
-                        &mut self.mixer,
-                        &path,
-                        value,
-                    ) {
-                        changed_params.push((path.clone(), value));
+                    } else {
+                        match crate::param_router::apply_param_by_path(
+                            &mut self.mixer,
+                            &path,
+                            value,
+                        ) {
+                            Ok(()) => changed_params.push((path.clone(), value)),
+                            Err(e) => log::warn!("MIDI param route failed ({path}): {e}"),
+                        }
                     }
                 } else if !self.input.midi_mappings.learn_mode {
                     log::debug!("Unmapped MIDI: {} value={:.2}", key, value);

--- a/src/internal/keymap/mod.rs
+++ b/src/internal/keymap/mod.rs
@@ -629,45 +629,12 @@ pub fn apply_keyboard_toggle_param(mixer: &mut crate::mixer::Mixer, path: &str) 
             }
             false
         }
-        // deck/<uuid>/effect/<k>/param/<name>
-        ["deck", uuid, "effect", ek_s, "param", name] => {
+        // deck/<uuid>/effect/<effect_uuid>/param/<name>
+        ["deck", uuid, "effect", fx_uuid, "param", name] => {
             if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if let Ok(ek) = ek_s.parse::<usize>() {
-                    let slot = &mut mixer.channels_mut()[ch].decks[dk];
-                    if ek < slot.deck.effects.len() {
-                        if let Some(val) = slot.deck.effects[ek].params.values.get_mut(*name) {
-                            toggle_param_value(val);
-                            return true;
-                        }
-                    }
-                }
-            }
-            false
-        }
-        // ch/<uuid>/effect/<k>/param/<name>
-        ["ch", ch_uuid, "effect", ek_s, "param", name] => {
-            if let Some(ch) = mixer.find_channel_by_uuid(ch_uuid) {
-                if let Ok(ek) = ek_s.parse::<usize>() {
-                    if ek < mixer.channels_mut()[ch].effects.len() {
-                        if let Some(val) = mixer.channels_mut()[ch].effects[ek]
-                            .params
-                            .values
-                            .get_mut(*name)
-                        {
-                            toggle_param_value(val);
-                            return true;
-                        }
-                    }
-                }
-            }
-            false
-        }
-        // master/effect/<k>/param/<name>
-        ["master", "effect", ek_s, "param", name] => {
-            if let Ok(ek) = ek_s.parse::<usize>() {
-                let effects = mixer.master_effects_mut();
-                if ek < effects.len() {
-                    if let Some(val) = effects[ek].params.values.get_mut(*name) {
+                let slot = &mut mixer.channels_mut()[ch].decks[dk];
+                if let Some(ek) = slot.deck.effects.iter().position(|e| e.uuid == *fx_uuid) {
+                    if let Some(val) = slot.deck.effects[ek].params.values.get_mut(*name) {
                         toggle_param_value(val);
                         return true;
                     }
@@ -675,8 +642,39 @@ pub fn apply_keyboard_toggle_param(mixer: &mut crate::mixer::Mixer, path: &str) 
             }
             false
         }
-        // mod/<idx>/<param> — modulation source params (toggle float between 0 and 1)
-        ["mod", _idx_s, _param] => {
+        // ch/<uuid>/effect/<effect_uuid>/param/<name>
+        ["ch", ch_uuid, "effect", fx_uuid, "param", name] => {
+            if let Some(ch) = mixer.find_channel_by_uuid(ch_uuid) {
+                if let Some(ek) = mixer.channels_mut()[ch]
+                    .effects
+                    .iter()
+                    .position(|e| e.uuid == *fx_uuid)
+                {
+                    if let Some(val) = mixer.channels_mut()[ch].effects[ek]
+                        .params
+                        .values
+                        .get_mut(*name)
+                    {
+                        toggle_param_value(val);
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        // master/effect/<effect_uuid>/param/<name>
+        ["master", "effect", fx_uuid, "param", name] => {
+            let effects = mixer.master_effects_mut();
+            if let Some(ek) = effects.iter().position(|e| e.uuid == *fx_uuid) {
+                if let Some(val) = effects[ek].params.values.get_mut(*name) {
+                    toggle_param_value(val);
+                    return true;
+                }
+            }
+            false
+        }
+        // mod/<mod_uuid>/<param> — modulation source params (toggle float between 0 and 1)
+        ["mod", _mod_uuid, _param] => {
             // Modulation params are continuous values; keyboard toggle doesn't apply well.
             // Fall through to default.
             false

--- a/src/internal/midi/controller_profile.rs
+++ b/src/internal/midi/controller_profile.rs
@@ -581,72 +581,58 @@ impl ControllerLedManager {
 // This is parameter semantics, not device knowledge. It maps parameter
 // state to logical color names that profiles resolve to MIDI values.
 
+/// Resolve a deck slot by its stable UUID, mirroring the parameter router.
+fn deck_slot_by_uuid<'a>(mixer: &'a Mixer, uuid: &str) -> Option<&'a crate::channel::DeckSlot> {
+    let (ch, dk) = mixer.find_deck_by_uuid(uuid)?;
+    mixer.channel(ch).and_then(|c| c.decks.get(dk))
+}
+
 /// Read a parameter value from the mixer. Returns 0.0–1.0 or -1.0 if not found.
+///
+/// Paths use stable UUIDs for channels, decks, and effects, matching the
+/// canonical format emitted by the UI and consumed by `param_router`. Any
+/// unresolved entity yields -1.0, which callers render as the "not found" LED
+/// color.
 fn read_param_value(mixer: &Mixer, path: &str) -> f32 {
     let parts: Vec<&str> = path.split('/').collect();
     match parts.as_slice() {
         ["crossfader"] => mixer.crossfader(),
-        ["ch", ch_s, "opacity"] => ch_s
-            .parse::<usize>()
-            .ok()
+        ["ch", ch_uuid, "opacity"] => mixer
+            .find_channel_by_uuid(ch_uuid)
             .and_then(|ch| mixer.channel(ch))
             .map(|c| c.opacity)
             .unwrap_or(-1.0),
-        ["ch", ch_s, "deck", dk_s, "opacity"] => {
-            if let (Ok(ch), Ok(dk)) = (ch_s.parse::<usize>(), dk_s.parse::<usize>()) {
-                mixer
-                    .channel(ch)
-                    .and_then(|c| c.decks.get(dk))
-                    .map(|d| d.opacity)
-                    .unwrap_or(-1.0)
-            } else {
-                -1.0
-            }
-        }
-        ["ch", ch_s, "deck", dk_s, "mute"] => {
-            if let (Ok(ch), Ok(dk)) = (ch_s.parse::<usize>(), dk_s.parse::<usize>()) {
-                mixer
-                    .channel(ch)
-                    .and_then(|c| c.decks.get(dk))
-                    .map(|d| if d.mute { 1.0 } else { 0.0 })
-                    .unwrap_or(-1.0)
-            } else {
-                -1.0
-            }
-        }
-        ["ch", ch_s, "deck", dk_s, "solo"] => {
-            if let (Ok(ch), Ok(dk)) = (ch_s.parse::<usize>(), dk_s.parse::<usize>()) {
-                mixer
-                    .channel(ch)
-                    .and_then(|c| c.decks.get(dk))
-                    .map(|d| if d.solo { 1.0 } else { 0.0 })
-                    .unwrap_or(-1.0)
-            } else {
-                -1.0
-            }
-        }
-        ["ch", ch_s, "deck", dk_s, "trigger"] => {
-            if let (Ok(ch), Ok(dk)) = (ch_s.parse::<usize>(), dk_s.parse::<usize>()) {
-                mixer
-                    .channel(ch)
-                    .and_then(|c| c.decks.get(dk))
-                    .map(|d| d.opacity)
-                    .unwrap_or(-1.0)
-            } else {
-                -1.0
-            }
-        }
-        ["ch", ch_s, "effect", ek_s, "param", name] => {
-            if let (Ok(ch), Ok(ek)) = (ch_s.parse::<usize>(), ek_s.parse::<usize>()) {
-                mixer
-                    .channel(ch)
-                    .and_then(|c| c.effects.get(ek))
-                    .and_then(|e| e.params.get_float(name))
-                    .unwrap_or(-1.0)
-            } else {
-                -1.0
-            }
-        }
+        ["deck", uuid, "opacity"] => deck_slot_by_uuid(mixer, uuid)
+            .map(|d| d.opacity)
+            .unwrap_or(-1.0),
+        ["deck", uuid, "mute"] => deck_slot_by_uuid(mixer, uuid)
+            .map(|d| if d.mute { 1.0 } else { 0.0 })
+            .unwrap_or(-1.0),
+        ["deck", uuid, "solo"] => deck_slot_by_uuid(mixer, uuid)
+            .map(|d| if d.solo { 1.0 } else { 0.0 })
+            .unwrap_or(-1.0),
+        ["deck", uuid, "trigger"] => deck_slot_by_uuid(mixer, uuid)
+            .map(|d| d.opacity)
+            .unwrap_or(-1.0),
+        ["deck", uuid, "param", name] => deck_slot_by_uuid(mixer, uuid)
+            .and_then(|d| d.deck.generator_params.get_float(name))
+            .unwrap_or(-1.0),
+        ["deck", uuid, "effect", fx_uuid, "param", name] => deck_slot_by_uuid(mixer, uuid)
+            .and_then(|d| d.deck.effects.iter().find(|e| e.uuid == *fx_uuid))
+            .and_then(|e| e.params.get_float(name))
+            .unwrap_or(-1.0),
+        ["ch", ch_uuid, "effect", fx_uuid, "param", name] => mixer
+            .find_channel_by_uuid(ch_uuid)
+            .and_then(|ch| mixer.channel(ch))
+            .and_then(|c| c.effects.iter().find(|e| e.uuid == *fx_uuid))
+            .and_then(|e| e.params.get_float(name))
+            .unwrap_or(-1.0),
+        ["master", "effect", fx_uuid, "param", name] => mixer
+            .master_effects()
+            .iter()
+            .find(|e| e.uuid == *fx_uuid)
+            .and_then(|e| e.params.get_float(name))
+            .unwrap_or(-1.0),
         _ => -1.0,
     }
 }
@@ -741,15 +727,60 @@ mod tests {
 
     #[test]
     fn test_param_value_to_color_mute() {
-        assert_eq!(param_value_to_color("ch/0/deck/0/mute", 1.0), "red");
-        assert_eq!(param_value_to_color("ch/0/deck/0/mute", 0.0), "off");
+        assert_eq!(param_value_to_color("deck/aabbccdd/mute", 1.0), "red");
+        assert_eq!(param_value_to_color("deck/aabbccdd/mute", 0.0), "off");
     }
 
     #[test]
     fn test_param_value_to_color_continuous() {
-        assert_eq!(param_value_to_color("ch/0/opacity", 0.0), "off");
-        assert_eq!(param_value_to_color("ch/0/opacity", 0.5), "yellow");
-        assert_eq!(param_value_to_color("ch/0/opacity", 1.0), "green");
+        assert_eq!(param_value_to_color("ch/aabbccdd/opacity", 0.0), "off");
+        assert_eq!(param_value_to_color("ch/aabbccdd/opacity", 0.5), "yellow");
+        assert_eq!(param_value_to_color("ch/aabbccdd/opacity", 1.0), "green");
+    }
+
+    // ── LED feedback reader resolves entities by stable UUID (matches
+    //    param_router). Regression guard: the reader previously parsed
+    //    positional indices, so every UUID path returned -1.0 (the
+    //    "not found" color) and LEDs never reflected mapped state.
+    #[test]
+    fn read_param_value_resolves_by_uuid_and_survives_reorder() {
+        use crate::renderer::GpuContext;
+
+        let gpu = GpuContext::new_headless().expect("headless GPU required for tests");
+        let mut mixer = Mixer::new(&gpu, 64, 64).unwrap();
+
+        let ch_uuid = mixer.channel(0).unwrap().uuid().to_string();
+        mixer.channel_mut(0).unwrap().opacity = 0.42;
+
+        // Two decks in channel 0; capture the second (positional index 1).
+        let first = crate::deck::Deck::new_solid_color(&gpu, [1.0, 0.0, 0.0, 1.0], 64, 64).unwrap();
+        let second =
+            crate::deck::Deck::new_solid_color(&gpu, [0.0, 1.0, 0.0, 1.0], 64, 64).unwrap();
+        mixer.channel_mut(0).unwrap().add_deck(first);
+        mixer.channel_mut(0).unwrap().add_deck(second);
+        let deck_uuid = mixer.channel(0).unwrap().decks[1].deck.uuid().to_string();
+        mixer.channel_mut(0).unwrap().decks[1].opacity = 0.7;
+        mixer.channel_mut(0).unwrap().decks[1].mute = true;
+
+        // UUID paths resolve to live values (would be -1.0 under index parsing).
+        assert!((read_param_value(&mixer, &format!("ch/{ch_uuid}/opacity")) - 0.42).abs() < 1e-4);
+        assert!(
+            (read_param_value(&mixer, &format!("deck/{deck_uuid}/opacity")) - 0.7).abs() < 1e-4
+        );
+        assert_eq!(
+            read_param_value(&mixer, &format!("deck/{deck_uuid}/mute")),
+            1.0
+        );
+
+        // Removing the earlier deck shifts positional indices; UUID still resolves.
+        mixer.channel_mut(0).unwrap().decks.remove(0);
+        assert!(
+            (read_param_value(&mixer, &format!("deck/{deck_uuid}/opacity")) - 0.7).abs() < 1e-4
+        );
+
+        // Unknown UUIDs yield the "not found" sentinel, not a wrong entity.
+        assert_eq!(read_param_value(&mixer, "deck/deadbeef/opacity"), -1.0);
+        assert_eq!(read_param_value(&mixer, "ch/deadbeef/opacity"), -1.0);
     }
 
     #[test]

--- a/src/internal/midi/mod.rs
+++ b/src/internal/midi/mod.rs
@@ -555,11 +555,11 @@ impl MidiDeviceManager {
 ///   crossfader                              → mixer crossfader position
 ///   deck/<uuid>/opacity                     → deck opacity
 ///   deck/<uuid>/param/<name>                → generator param (float)
-///   deck/<uuid>/effect/<k>/param/<name>     → deck effect param (float)
+///   deck/<uuid>/effect/<effect_uuid>/param/<name> → deck effect param (float)
 ///   ch/<uuid>/opacity                       → channel opacity
-///   ch/<uuid>/effect/<k>/param/<name>       → channel effect param (float)
-///   master/effect/<k>/param/<name>          → master effect param (float)
-///   mod/<idx>/<param_name>                  → modulation source param
+///   ch/<uuid>/effect/<effect_uuid>/param/<name>   → channel effect param (float)
+///   master/effect/<effect_uuid>/param/<name>      → master effect param (float)
+///   mod/<mod_uuid>/<param_name>             → modulation source param
 #[derive(Debug, Clone)]
 pub struct MidiMappingStore {
     /// MidiKey → parameter path

--- a/src/internal/midi/mod.rs
+++ b/src/internal/midi/mod.rs
@@ -903,7 +903,7 @@ mod tests {
     fn test_mapping_store_clear_all() {
         let mut store = MidiMappingStore::new();
         store.set(MidiKey::CC(0, 0, 48), "crossfader".to_string());
-        store.set(MidiKey::Note(1, 0, 36), "ch/0/opacity".to_string());
+        store.set(MidiKey::Note(1, 0, 36), "ch/aabbccdd/opacity".to_string());
         assert_eq!(store.mappings.len(), 2);
         store.clear_all();
         assert_eq!(store.mappings.len(), 0);
@@ -1002,7 +1002,7 @@ mod tests {
                 msg_type: "cc".into(),
                 channel: 0,
                 number: 48,
-                param_path: "ch/0/opacity".into(),
+                param_path: "ch/aabbccdd/opacity".into(),
             }],
         };
         assert!(config.validate().is_empty());
@@ -1015,7 +1015,7 @@ mod tests {
             msg_type: "cc".into(),
             channel: 0,
             number: 0,
-            param_path: "ch/0/opacity".into(),
+            param_path: "ch/aabbccdd/opacity".into(),
         };
         assert!(entry
             .validate("m[0]")
@@ -1030,7 +1030,7 @@ mod tests {
             msg_type: "sysex".into(),
             channel: 0,
             number: 0,
-            param_path: "ch/0/opacity".into(),
+            param_path: "ch/aabbccdd/opacity".into(),
         };
         assert!(entry
             .validate("m[0]")
@@ -1045,7 +1045,7 @@ mod tests {
             msg_type: "note".into(),
             channel: 16,
             number: 60,
-            param_path: "ch/0/opacity".into(),
+            param_path: "ch/aabbccdd/opacity".into(),
         };
         assert!(entry.validate("m[0]").iter().any(|e| e.contains("channel")));
     }
@@ -1136,15 +1136,15 @@ mod tests {
         // Auto-mapped key (grid note within 0–63) — should be filtered
         store
             .mappings
-            .insert(MidiKey::Note(dev_id, 0, 10), "ch/0/deck/0/play".into());
+            .insert(MidiKey::Note(dev_id, 0, 10), "deck/aabbccdd/trigger".into());
         // Auto-mapped key (fader CC within 48–55) — should be filtered
         store
             .mappings
-            .insert(MidiKey::CC(dev_id, 0, 50), "ch/0/opacity".into());
+            .insert(MidiKey::CC(dev_id, 0, 50), "ch/aabbccdd/opacity".into());
         // Manual mapping (CC outside auto-map range) — should be kept
         store
             .mappings
-            .insert(MidiKey::CC(dev_id, 0, 99), "ch/1/opacity".into());
+            .insert(MidiKey::CC(dev_id, 0, 99), "ch/eeff0011/opacity".into());
 
         let mut devices = HashMap::new();
         devices.insert(
@@ -1160,7 +1160,7 @@ mod tests {
 
         let config = store.to_config(&devices, &auto_map);
         assert_eq!(config.mappings.len(), 1);
-        assert_eq!(config.mappings[0].param_path, "ch/1/opacity");
+        assert_eq!(config.mappings[0].param_path, "ch/eeff0011/opacity");
         assert_eq!(config.mappings[0].number, 99);
     }
 
@@ -1172,10 +1172,10 @@ mod tests {
         let mut store = MidiMappingStore::new();
         store
             .mappings
-            .insert(MidiKey::Note(dev_id, 0, 10), "ch/0/deck/0/play".into());
+            .insert(MidiKey::Note(dev_id, 0, 10), "deck/aabbccdd/trigger".into());
         store
             .mappings
-            .insert(MidiKey::CC(dev_id, 0, 50), "ch/0/opacity".into());
+            .insert(MidiKey::CC(dev_id, 0, 50), "ch/aabbccdd/opacity".into());
 
         let mut devices = HashMap::new();
         devices.insert(

--- a/src/internal/mixer/mod.rs
+++ b/src/internal/mixer/mod.rs
@@ -879,4 +879,53 @@ mod tests {
         assert_eq!(mixer.channel(0).unwrap().active_deck_count, 1);
         assert_eq!(mixer.channel(1).unwrap().active_deck_count, 0);
     }
+
+    // ── Parameter router: UUID addressing survives reorder (WS2) ─────
+    //
+    // Regression guard for /spec/parameter-routing.md: modulators are
+    // addressed by stable UUID, so removing an earlier source (which shifts
+    // positional indices) must not retarget a saved binding.
+
+    #[test]
+    fn param_router_addresses_modulator_by_uuid_after_reorder() {
+        use crate::modulation::ModulationSource;
+        use crate::param_router::{apply_param_by_path, EntityKind, ParamRouteError};
+
+        let gpu = headless_gpu();
+        let mut mixer = Mixer::new(&gpu, 64, 64).unwrap();
+
+        // Two LFOs; `b` starts at positional index 1.
+        let a = mixer
+            .modulation_mut()
+            .add_source(ModulationSource::sine_lfo(1.0));
+        let b = mixer
+            .modulation_mut()
+            .add_source(ModulationSource::sine_lfo(1.0));
+
+        // Remove `a` → `b` shifts to positional index 0. Under the old
+        // index-based router, `mod/<b>` would have missed or hit the wrong
+        // source; under UUID addressing it still resolves to `b`.
+        mixer.modulation_mut().remove_source(&a);
+
+        let path = format!("mod/{b}/frequency");
+        assert!(apply_param_by_path(&mut mixer, &path, 0.5).is_ok());
+
+        // 0.01 + 0.5 * 9.99 = 5.005 proves `b` was the source mutated.
+        let entry = mixer.modulation().find_source_by_uuid(&b).unwrap();
+        if let ModulationSource::LFO { frequency, .. } = entry.source {
+            assert!((frequency - 5.005).abs() < 1e-4, "frequency = {frequency}");
+        } else {
+            panic!("expected LFO");
+        }
+
+        // Unknown modulator UUID resolves to a structured error, not a silent no-op.
+        let err = apply_param_by_path(&mut mixer, "mod/deadbeef/frequency", 0.5).unwrap_err();
+        assert!(matches!(
+            err,
+            ParamRouteError::UnknownEntity {
+                kind: EntityKind::Modulator,
+                ..
+            }
+        ));
+    }
 }

--- a/src/internal/modulation/engine.rs
+++ b/src/internal/modulation/engine.rs
@@ -492,6 +492,12 @@ impl ModulationEngine {
         self.sources.iter().find(|e| e.uuid == uuid)
     }
 
+    /// Find an existing source by UUID (mutable). Used by the parameter router
+    /// to address modulators by stable identity rather than positional index.
+    pub fn find_source_by_uuid_mut(&mut self, uuid: &str) -> Option<&mut ModulationSourceEntry> {
+        self.sources.iter_mut().find(|e| e.uuid == uuid)
+    }
+
     /// Iterate over all assignments (key → modulations).
     pub fn assignments_iter(
         &self,

--- a/src/internal/osc/mod.rs
+++ b/src/internal/osc/mod.rs
@@ -299,11 +299,11 @@ mod tests {
 
     #[test]
     fn parse_param_mod_frequency() {
-        let input = parse_osc_message("/varda/mod/2/frequency", &[OscType::Float(0.5)]);
+        let input = parse_osc_message("/varda/mod/lfo123ab/frequency", &[OscType::Float(0.5)]);
         assert_eq!(
             input,
             OscInput::Param {
-                path: "mod/2/frequency".into(),
+                path: "mod/lfo123ab/frequency".into(),
                 value: 0.5
             }
         );
@@ -396,13 +396,13 @@ mod tests {
     #[test]
     fn parse_deep_path_effect_param() {
         let input = parse_osc_message(
-            "/varda/deck/abc/effect/0/param/brightness",
+            "/varda/deck/abc/effect/fx0011aa/param/brightness",
             &[OscType::Float(0.7)],
         );
         assert_eq!(
             input,
             OscInput::Param {
-                path: "deck/abc/effect/0/param/brightness".into(),
+                path: "deck/abc/effect/fx0011aa/param/brightness".into(),
                 value: 0.7
             },
         );
@@ -411,13 +411,13 @@ mod tests {
     #[test]
     fn parse_master_effect_param() {
         let input = parse_osc_message(
-            "/varda/master/effect/1/param/amount",
+            "/varda/master/effect/fx22bb33/param/amount",
             &[OscType::Float(0.3)],
         );
         assert_eq!(
             input,
             OscInput::Param {
-                path: "master/effect/1/param/amount".into(),
+                path: "master/effect/fx22bb33/param/amount".into(),
                 value: 0.3
             },
         );
@@ -437,11 +437,11 @@ mod tests {
 
     #[test]
     fn parse_step_sequencer_step() {
-        let input = parse_osc_message("/varda/mod/0/step/3", &[OscType::Float(0.6)]);
+        let input = parse_osc_message("/varda/mod/lfo123ab/step/3", &[OscType::Float(0.6)]);
         assert_eq!(
             input,
             OscInput::Param {
-                path: "mod/0/step/3".into(),
+                path: "mod/lfo123ab/step/3".into(),
                 value: 0.6
             }
         );

--- a/src/internal/param_router.rs
+++ b/src/internal/param_router.rs
@@ -1,8 +1,15 @@
 //! Shared parameter path router for external control protocols (MIDI, OSC).
 //!
-//! Maps path strings like `deck/<uuid>/opacity` or `mod/0/frequency` to
+//! Maps path strings like `deck/<uuid>/opacity` or `mod/<uuid>/frequency` to
 //! concrete mixer mutations. All values are normalized 0.0–1.0 and scaled
 //! to the target parameter's native range.
+//!
+//! Entities are addressed by **stable UUID**, never positional index — decks,
+//! channels, effects, and modulation sources all carry 8-char hex UUIDs (see
+//! `/spec/entity-identity.md`). Reordering a chain or rack therefore never
+//! retargets a saved binding. Resolution failures return a structured
+//! [`ParamRouteError`] so callers can log or surface the specific reason
+//! rather than a silent no-op (see `/spec/parameter-routing.md`).
 
 use crate::deck::ScalingMode;
 use crate::mixer::Mixer;
@@ -10,260 +17,471 @@ use crate::modulation::ModulationSource;
 use crate::params::ParamValue;
 use crate::video::LoopMode;
 
-/// Apply a normalized value (0.0–1.0) to the parameter at the given path.
-/// Returns true if the path resolved successfully.
-pub fn apply_param_by_path(mixer: &mut Mixer, path: &str, value: f32) -> bool {
-    let parts: Vec<&str> = path.split('/').collect();
-    match parts.as_slice() {
-        ["crossfader"] => {
-            mixer.snap_crossfader(value);
-            true
-        }
-        ["deck", uuid, "opacity"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                let v = if value.is_finite() {
-                    value.clamp(0.0, 1.0)
-                } else {
-                    1.0
-                };
-                mixer.channels_mut()[ch].decks[dk].opacity = v;
-                return true;
-            }
-            false
-        }
-        ["deck", uuid, "mute"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if value > 0.5 {
-                    let m = mixer.channels_mut()[ch].decks[dk].mute;
-                    mixer.channels_mut()[ch].decks[dk].mute = !m;
-                }
-                return true;
-            }
-            false
-        }
-        ["deck", uuid, "solo"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if value > 0.5 {
-                    let s = mixer.channels_mut()[ch].decks[dk].solo;
-                    mixer.channels_mut()[ch].decks[dk].solo = !s;
-                }
-                return true;
-            }
-            false
-        }
-        ["deck", uuid, "trigger"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if value > 0.5 {
-                    mixer.channels_mut()[ch].decks[dk].opacity = 1.0;
-                }
-                return true;
-            }
-            false
-        }
-        ["deck", uuid, "at", "play_duration"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if let Some(ref mut at) = mixer.channels_mut()[ch].decks[dk].auto_transition {
-                    let max = if at.play_duration.is_beats() {
-                        128.0
-                    } else {
-                        300.0
-                    };
-                    at.play_duration.set_value(0.5 + value as f64 * (max - 0.5));
-                    return true;
-                }
-            }
-            false
-        }
-        ["deck", uuid, "at", "trans_duration"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if let Some(ref mut at) = mixer.channels_mut()[ch].decks[dk].auto_transition {
-                    let max = if at.transition_duration.is_beats() {
-                        32.0
-                    } else {
-                        30.0
-                    };
-                    at.transition_duration
-                        .set_value(0.1 + value as f64 * (max - 0.1));
-                    return true;
-                }
-            }
-            false
-        }
-        ["deck", uuid, "video", "play"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                return mixer.channels_mut()[ch].decks[dk]
-                    .deck
-                    .video_set_playing(value > 0.5);
-            }
-            false
-        }
-        ["deck", uuid, "video", "speed"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                return mixer.channels_mut()[ch].decks[dk]
-                    .deck
-                    .video_set_speed(scale_speed(value));
-            }
-            false
-        }
-        ["deck", uuid, "video", "seek"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                let deck = &mixer.channels_mut()[ch].decks[dk].deck;
-                if let Some(snap) = deck.playback_snapshot() {
-                    return deck.video_seek(scale_to_duration(value, snap.duration));
-                }
-            }
-            false
-        }
-        ["deck", uuid, "video", "in_point"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                let deck = &mixer.channels_mut()[ch].decks[dk].deck;
-                if let Some(snap) = deck.playback_snapshot() {
-                    return deck.video_set_in_point(scale_to_duration(value, snap.duration));
-                }
-            }
-            false
-        }
-        ["deck", uuid, "video", "out_point"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                let deck = &mixer.channels_mut()[ch].decks[dk].deck;
-                if let Some(snap) = deck.playback_snapshot() {
-                    return deck.video_set_out_point(scale_to_duration(value, snap.duration));
-                }
-            }
-            false
-        }
-        ["deck", uuid, "video", "clear"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if value > 0.5 {
-                    return mixer.channels_mut()[ch].decks[dk]
-                        .deck
-                        .video_clear_in_out_points();
-                }
-                return true;
-            }
-            false
-        }
-        ["deck", uuid, "video", "loop_mode"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                return mixer.channels_mut()[ch].decks[dk]
-                    .deck
-                    .video_set_loop_mode(loop_mode_from_value(value));
-            }
-            false
-        }
-        ["deck", uuid, "scaling_mode"] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                mixer.channels_mut()[ch].decks[dk]
-                    .deck
-                    .set_scaling_mode(scaling_mode_from_value(value));
-                return true;
-            }
-            false
-        }
-        ["deck", uuid, "param", name] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                apply_float_param_scaled(
-                    &mut mixer.channels_mut()[ch].decks[dk].deck.generator_params,
-                    name,
-                    value,
-                );
-                return true;
-            }
-            false
-        }
-        ["deck", uuid, "effect", ek_s, "param", name] => {
-            if let Some((ch, dk)) = mixer.find_deck_by_uuid(uuid) {
-                if let Ok(ek) = ek_s.parse::<usize>() {
-                    let decks = &mut mixer.channels_mut()[ch].decks;
-                    if ek < decks[dk].deck.effects.len() {
-                        apply_float_param_scaled(
-                            &mut decks[dk].deck.effects[ek].params,
-                            name,
-                            value,
-                        );
-                        return true;
-                    }
-                }
-            }
-            false
-        }
-        ["ch", ch_uuid, "opacity"] => {
-            if let Some(ch) = mixer.find_channel_by_uuid(ch_uuid) {
-                let v = if value.is_finite() {
-                    value.clamp(0.0, 1.0)
-                } else {
-                    1.0
-                };
-                mixer.channels_mut()[ch].opacity = v;
-                return true;
-            }
-            false
-        }
-        ["ch", ch_uuid, "effect", ek_s, "param", name] => {
-            if let Some(ch) = mixer.find_channel_by_uuid(ch_uuid) {
-                if let Ok(ek) = ek_s.parse::<usize>() {
-                    if ek < mixer.channels_mut()[ch].effects.len() {
-                        apply_float_param_scaled(
-                            &mut mixer.channels_mut()[ch].effects[ek].params,
-                            name,
-                            value,
-                        );
-                        return true;
-                    }
-                }
-            }
-            false
-        }
-        ["master", "effect", ek_s, "param", name] => {
-            if let Ok(ek) = ek_s.parse::<usize>() {
-                if ek < mixer.master_effects().len() {
-                    apply_float_param_scaled(
-                        &mut mixer.master_effects_mut()[ek].params,
-                        name,
-                        value,
-                    );
-                    return true;
-                }
-            }
-            false
-        }
-        ["mod", idx_s, param_name] => {
-            if let Ok(idx) = idx_s.parse::<usize>() {
-                if idx < mixer.modulation_mut().sources.len() {
-                    apply_mod_param(
-                        &mut mixer.modulation_mut().sources[idx].source,
-                        param_name,
-                        value,
-                    );
-                    return true;
-                }
-            }
-            false
-        }
-        ["mod", idx_s, "step", step_s] => {
-            if let (Ok(idx), Ok(step_idx)) = (idx_s.parse::<usize>(), step_s.parse::<usize>()) {
-                if idx < mixer.modulation_mut().sources.len() {
-                    if let ModulationSource::StepSequencer { steps, .. } =
-                        &mut mixer.modulation_mut().sources[idx].source
-                    {
-                        if step_idx < steps.len() {
-                            steps[step_idx] = value.clamp(0.0, 1.0);
-                            return true;
-                        }
-                    }
-                }
-            }
-            false
-        }
-        _ => {
-            log::warn!("Unknown parameter path: {}", path);
-            false
+/// The class of entity a path segment addresses. Used in [`ParamRouteError`]
+/// to describe *what* failed to resolve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntityKind {
+    Deck,
+    Channel,
+    Effect,
+    Modulator,
+    Step,
+}
+
+impl std::fmt::Display for EntityKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            EntityKind::Deck => "deck",
+            EntityKind::Channel => "channel",
+            EntityKind::Effect => "effect",
+            EntityKind::Modulator => "modulator",
+            EntityKind::Step => "step",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Why a parameter path failed to apply. Replaces the previous bare `bool`
+/// so MIDI/OSC/API callers can log the specific reason instead of silently
+/// dropping the mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParamRouteError {
+    /// The path did not match any known parameter route.
+    UnknownPath { path: String },
+    /// A structurally-valid path referenced an entity UUID that does not exist.
+    UnknownEntity { kind: EntityKind, id: String },
+    /// An index (e.g. a step-sequencer step) is out of range for its container.
+    IndexOutOfRange {
+        kind: EntityKind,
+        index: usize,
+        len: usize,
+    },
+    /// The entity resolved but is in a state that can't accept this mutation
+    /// (e.g. a deck with no auto-transition, or a non-step-sequencer modulator).
+    WrongState { path: String, reason: &'static str },
+    /// The entity resolved but the named sub-parameter is unknown.
+    UnknownParam { scope: &'static str, name: String },
+}
+
+impl ParamRouteError {
+    fn unknown_entity(kind: EntityKind, id: &str) -> Self {
+        ParamRouteError::UnknownEntity {
+            kind,
+            id: id.to_string(),
         }
     }
 }
 
+impl std::fmt::Display for ParamRouteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParamRouteError::UnknownPath { path } => write!(f, "unknown parameter path: {path}"),
+            ParamRouteError::UnknownEntity { kind, id } => {
+                write!(f, "unknown {kind}: {id}")
+            }
+            ParamRouteError::IndexOutOfRange { kind, index, len } => {
+                write!(f, "{kind} index {index} out of range (len {len})")
+            }
+            ParamRouteError::WrongState { path, reason } => {
+                write!(f, "cannot apply {path}: {reason}")
+            }
+            ParamRouteError::UnknownParam { scope, name } => {
+                write!(f, "unknown {scope} param: {name}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ParamRouteError {}
+
+/// Convert an inner "did the mixer op succeed" bool into a `Result`, attributing
+/// a `false` to a [`ParamRouteError::WrongState`] with the given reason.
+fn ok_or_state(applied: bool, path: &str, reason: &'static str) -> Result<(), ParamRouteError> {
+    if applied {
+        Ok(())
+    } else {
+        Err(ParamRouteError::WrongState {
+            path: path.to_string(),
+            reason,
+        })
+    }
+}
+
+/// Apply a normalized value (0.0–1.0) to the parameter at the given path.
+/// Returns `Ok(())` if the path resolved and the mutation was applied, or a
+/// [`ParamRouteError`] describing why it did not.
+pub fn apply_param_by_path(
+    mixer: &mut Mixer,
+    path: &str,
+    value: f32,
+) -> Result<(), ParamRouteError> {
+    let parts: Vec<&str> = path.split('/').collect();
+    match parts.as_slice() {
+        ["crossfader"] => {
+            mixer.snap_crossfader(value);
+            Ok(())
+        }
+        ["deck", uuid, "opacity"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            mixer.channels_mut()[ch].decks[dk].opacity = clamp_or_full(value);
+            Ok(())
+        }
+        ["deck", uuid, "mute"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            if value > 0.5 {
+                let m = mixer.channels_mut()[ch].decks[dk].mute;
+                mixer.channels_mut()[ch].decks[dk].mute = !m;
+            }
+            Ok(())
+        }
+        ["deck", uuid, "solo"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            if value > 0.5 {
+                let s = mixer.channels_mut()[ch].decks[dk].solo;
+                mixer.channels_mut()[ch].decks[dk].solo = !s;
+            }
+            Ok(())
+        }
+        ["deck", uuid, "trigger"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            if value > 0.5 {
+                mixer.channels_mut()[ch].decks[dk].opacity = 1.0;
+            }
+            Ok(())
+        }
+        ["deck", uuid, "at", "play_duration"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let slot = &mut mixer.channels_mut()[ch].decks[dk];
+            let at = slot
+                .auto_transition
+                .as_mut()
+                .ok_or(ParamRouteError::WrongState {
+                    path: path.to_string(),
+                    reason: "deck has no auto-transition",
+                })?;
+            let max = if at.play_duration.is_beats() {
+                128.0
+            } else {
+                300.0
+            };
+            at.play_duration.set_value(0.5 + value as f64 * (max - 0.5));
+            Ok(())
+        }
+        ["deck", uuid, "at", "trans_duration"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let slot = &mut mixer.channels_mut()[ch].decks[dk];
+            let at = slot
+                .auto_transition
+                .as_mut()
+                .ok_or(ParamRouteError::WrongState {
+                    path: path.to_string(),
+                    reason: "deck has no auto-transition",
+                })?;
+            let max = if at.transition_duration.is_beats() {
+                32.0
+            } else {
+                30.0
+            };
+            at.transition_duration
+                .set_value(0.1 + value as f64 * (max - 0.1));
+            Ok(())
+        }
+        ["deck", uuid, "video", "play"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let applied = mixer.channels_mut()[ch].decks[dk]
+                .deck
+                .video_set_playing(value > 0.5);
+            ok_or_state(applied, path, "deck has no video source")
+        }
+        ["deck", uuid, "video", "speed"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let applied = mixer.channels_mut()[ch].decks[dk]
+                .deck
+                .video_set_speed(scale_speed(value));
+            ok_or_state(applied, path, "deck has no video source")
+        }
+        ["deck", uuid, "video", "seek"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let deck = &mixer.channels_mut()[ch].decks[dk].deck;
+            let snap = deck
+                .playback_snapshot()
+                .ok_or(ParamRouteError::WrongState {
+                    path: path.to_string(),
+                    reason: "deck has no playable video",
+                })?;
+            let applied = deck.video_seek(scale_to_duration(value, snap.duration));
+            ok_or_state(applied, path, "video seek failed")
+        }
+        ["deck", uuid, "video", "in_point"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let deck = &mixer.channels_mut()[ch].decks[dk].deck;
+            let snap = deck
+                .playback_snapshot()
+                .ok_or(ParamRouteError::WrongState {
+                    path: path.to_string(),
+                    reason: "deck has no playable video",
+                })?;
+            let applied = deck.video_set_in_point(scale_to_duration(value, snap.duration));
+            ok_or_state(applied, path, "set in-point failed")
+        }
+        ["deck", uuid, "video", "out_point"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let deck = &mixer.channels_mut()[ch].decks[dk].deck;
+            let snap = deck
+                .playback_snapshot()
+                .ok_or(ParamRouteError::WrongState {
+                    path: path.to_string(),
+                    reason: "deck has no playable video",
+                })?;
+            let applied = deck.video_set_out_point(scale_to_duration(value, snap.duration));
+            ok_or_state(applied, path, "set out-point failed")
+        }
+        ["deck", uuid, "video", "clear"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            if value > 0.5 {
+                let applied = mixer.channels_mut()[ch].decks[dk]
+                    .deck
+                    .video_clear_in_out_points();
+                ok_or_state(applied, path, "clear in/out points failed")
+            } else {
+                Ok(())
+            }
+        }
+        ["deck", uuid, "video", "loop_mode"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let applied = mixer.channels_mut()[ch].decks[dk]
+                .deck
+                .video_set_loop_mode(loop_mode_from_value(value));
+            ok_or_state(applied, path, "deck has no video source")
+        }
+        ["deck", uuid, "scaling_mode"] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            mixer.channels_mut()[ch].decks[dk]
+                .deck
+                .set_scaling_mode(scaling_mode_from_value(value));
+            Ok(())
+        }
+        ["deck", uuid, "param", name] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            apply_float_param_scaled(
+                &mut mixer.channels_mut()[ch].decks[dk].deck.generator_params,
+                name,
+                value,
+            );
+            Ok(())
+        }
+        ["deck", uuid, "effect", fx_uuid, "param", name] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let effects = &mut mixer.channels_mut()[ch].decks[dk].deck.effects;
+            let ek = effects
+                .iter()
+                .position(|e| e.uuid == *fx_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Effect, fx_uuid))?;
+            apply_float_param_scaled(&mut effects[ek].params, name, value);
+            Ok(())
+        }
+        ["ch", ch_uuid, "opacity"] => {
+            let ch = mixer
+                .find_channel_by_uuid(ch_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Channel, ch_uuid))?;
+            mixer.channels_mut()[ch].opacity = clamp_or_full(value);
+            Ok(())
+        }
+        ["ch", ch_uuid, "effect", fx_uuid, "param", name] => {
+            let ch = mixer
+                .find_channel_by_uuid(ch_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Channel, ch_uuid))?;
+            let effects = &mut mixer.channels_mut()[ch].effects;
+            let ek = effects
+                .iter()
+                .position(|e| e.uuid == *fx_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Effect, fx_uuid))?;
+            apply_float_param_scaled(&mut effects[ek].params, name, value);
+            Ok(())
+        }
+        ["master", "effect", fx_uuid, "param", name] => {
+            let effects = mixer.master_effects_mut();
+            let ek = effects
+                .iter()
+                .position(|e| e.uuid == *fx_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Effect, fx_uuid))?;
+            apply_float_param_scaled(&mut effects[ek].params, name, value);
+            Ok(())
+        }
+        ["mod", mod_uuid, "step", step_s] => {
+            let step_idx = step_s
+                .parse::<usize>()
+                .map_err(|_| ParamRouteError::UnknownPath {
+                    path: path.to_string(),
+                })?;
+            let entry = mixer
+                .modulation_mut()
+                .find_source_by_uuid_mut(mod_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Modulator, mod_uuid))?;
+            if let ModulationSource::StepSequencer { steps, .. } = &mut entry.source {
+                if step_idx < steps.len() {
+                    steps[step_idx] = value.clamp(0.0, 1.0);
+                    Ok(())
+                } else {
+                    Err(ParamRouteError::IndexOutOfRange {
+                        kind: EntityKind::Step,
+                        index: step_idx,
+                        len: steps.len(),
+                    })
+                }
+            } else {
+                Err(ParamRouteError::WrongState {
+                    path: path.to_string(),
+                    reason: "modulator is not a step sequencer",
+                })
+            }
+        }
+        ["mod", mod_uuid, param_name] => {
+            let entry = mixer
+                .modulation_mut()
+                .find_source_by_uuid_mut(mod_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Modulator, mod_uuid))?;
+            apply_mod_param(&mut entry.source, param_name, value)
+        }
+        _ => Err(ParamRouteError::UnknownPath {
+            path: path.to_string(),
+        }),
+    }
+}
+
+/// Apply a typed [`ParamValue`] to the parameter at the given path.
+///
+/// For the shader/effect **param** paths this preserves the value's type —
+/// `Color`/`Point2D`/`Bool`/`Long` are written intact, and `Float` is
+/// normalized-scaled against the ISF definition exactly as the fader path does.
+/// Every other (inherently scalar) path delegates to [`apply_param_by_path`]
+/// after flattening the value to a normalized f32.
+///
+/// This is the entry point for the engine `set_param` trait; MIDI/OSC continue
+/// to use the normalized-f32 [`apply_param_by_path`].
+pub fn apply_typed_param_by_path(
+    mixer: &mut Mixer,
+    path: &str,
+    value: ParamValue,
+) -> Result<(), ParamRouteError> {
+    let parts: Vec<&str> = path.split('/').collect();
+    match parts.as_slice() {
+        ["deck", uuid, "param", name] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            apply_typed_param(
+                &mut mixer.channels_mut()[ch].decks[dk].deck.generator_params,
+                name,
+                value,
+            );
+            Ok(())
+        }
+        ["deck", uuid, "effect", fx_uuid, "param", name] => {
+            let (ch, dk) = mixer
+                .find_deck_by_uuid(uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Deck, uuid))?;
+            let effects = &mut mixer.channels_mut()[ch].decks[dk].deck.effects;
+            let ek = effects
+                .iter()
+                .position(|e| e.uuid == *fx_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Effect, fx_uuid))?;
+            apply_typed_param(&mut effects[ek].params, name, value);
+            Ok(())
+        }
+        ["ch", ch_uuid, "effect", fx_uuid, "param", name] => {
+            let ch = mixer
+                .find_channel_by_uuid(ch_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Channel, ch_uuid))?;
+            let effects = &mut mixer.channels_mut()[ch].effects;
+            let ek = effects
+                .iter()
+                .position(|e| e.uuid == *fx_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Effect, fx_uuid))?;
+            apply_typed_param(&mut effects[ek].params, name, value);
+            Ok(())
+        }
+        ["master", "effect", fx_uuid, "param", name] => {
+            let effects = mixer.master_effects_mut();
+            let ek = effects
+                .iter()
+                .position(|e| e.uuid == *fx_uuid)
+                .ok_or_else(|| ParamRouteError::unknown_entity(EntityKind::Effect, fx_uuid))?;
+            apply_typed_param(&mut effects[ek].params, name, value);
+            Ok(())
+        }
+        // Inherently-scalar paths (opacity, crossfader, video, mod, …): flatten.
+        _ => apply_param_by_path(mixer, path, param_value_to_norm_f32(&value)),
+    }
+}
+
+/// Flatten a [`ParamValue`] to the normalized f32 the scalar router expects.
+/// Non-scalar values collapse to their first component (colors → R, points → x);
+/// this is only used for paths that are inherently scalar.
+pub fn param_value_to_norm_f32(value: &ParamValue) -> f32 {
+    match value {
+        ParamValue::Float(v) => *v,
+        ParamValue::Bool(b) => {
+            if *b {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        ParamValue::Long(i) => *i as f32,
+        ParamValue::Color(c) => c[0],
+        ParamValue::Point2D(p) => p[0],
+    }
+}
+
+/// Set a typed value on a shader param: `Float` is normalized-scaled against the
+/// param definition (matching the fader path); every other variant is written
+/// as-is so colors and 2D points keep their type and full channel data.
+fn apply_typed_param(params: &mut crate::ShaderParams, name: &str, value: ParamValue) {
+    match value {
+        ParamValue::Float(v) => apply_float_param_scaled(params, name, v),
+        other => params.set(name, other),
+    }
+}
+
 /// Apply a normalized value to a modulation source parameter.
-fn apply_mod_param(source: &mut ModulationSource, param_name: &str, value: f32) {
+fn apply_mod_param(
+    source: &mut ModulationSource,
+    param_name: &str,
+    value: f32,
+) -> Result<(), ParamRouteError> {
     match source {
         ModulationSource::LFO {
             frequency,
@@ -274,11 +492,33 @@ fn apply_mod_param(source: &mut ModulationSource, param_name: &str, value: f32) 
             "frequency" => *frequency = 0.01 + value * 9.99,
             "amplitude" => *amplitude = value.clamp(0.0, 1.0),
             "phase" => *phase = value.clamp(0.0, 1.0),
-            _ => log::warn!("Unknown LFO param: {}", param_name),
+            _ => {
+                return Err(ParamRouteError::UnknownParam {
+                    scope: "LFO",
+                    name: param_name.to_string(),
+                })
+            }
         },
-        ModulationSource::AudioBand { smoothing, .. } => match param_name {
+        ModulationSource::AudioBand {
+            freq_low,
+            freq_high,
+            gain,
+            smoothing,
+            noise_gate,
+            ..
+        } => match param_name {
+            // Native ranges match the UI sliders (see modulation panel).
+            "freq_low" => *freq_low = 20.0 + clamp_norm(value) * (20000.0 - 20.0),
+            "freq_high" => *freq_high = 20.0 + clamp_norm(value) * (20000.0 - 20.0),
+            "gain" => *gain = clamp_norm(value) * 4.0,
             "smoothing" => *smoothing = (value * 0.99).clamp(0.0, 0.99),
-            _ => log::warn!("Unknown Audio param: {}", param_name),
+            "noise_gate" => *noise_gate = clamp_norm(value) * 0.5,
+            _ => {
+                return Err(ParamRouteError::UnknownParam {
+                    scope: "Audio",
+                    name: param_name.to_string(),
+                })
+            }
         },
         ModulationSource::ADSR {
             attack,
@@ -298,17 +538,33 @@ fn apply_mod_param(source: &mut ModulationSource, param_name: &str, value: f32) 
                     source.gate_off();
                 }
             }
-            _ => log::warn!("Unknown ADSR param: {}", param_name),
+            _ => {
+                return Err(ParamRouteError::UnknownParam {
+                    scope: "ADSR",
+                    name: param_name.to_string(),
+                })
+            }
         },
         ModulationSource::StepSequencer { rate, .. } => match param_name {
             "rate" => *rate = 0.1 + value * 19.9,
-            _ => log::warn!("Unknown StepSeq param: {}", param_name),
+            _ => {
+                return Err(ParamRouteError::UnknownParam {
+                    scope: "StepSeq",
+                    name: param_name.to_string(),
+                })
+            }
         },
         ModulationSource::Analyzer { smoothing, .. } => match param_name {
             "smoothing" => *smoothing = (value * 0.99).clamp(0.0, 0.99),
-            _ => log::warn!("Unknown Analyzer param: {}", param_name),
+            _ => {
+                return Err(ParamRouteError::UnknownParam {
+                    scope: "Analyzer",
+                    name: param_name.to_string(),
+                })
+            }
         },
     }
+    Ok(())
 }
 
 /// Apply a normalized 0.0–1.0 value to a float param, scaling to the param's min/max range.
@@ -320,6 +576,16 @@ fn apply_float_param_scaled(params: &mut crate::ShaderParams, name: &str, normal
         params.set(name, ParamValue::Float(scaled));
     } else {
         params.set(name, ParamValue::Float(normalized));
+    }
+}
+
+/// Clamp a value to 0.0–1.0, treating non-finite input as `1.0` (used for
+/// opacity, where a garbled value should fail safe to fully-visible).
+fn clamp_or_full(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(0.0, 1.0)
+    } else {
+        1.0
     }
 }
 
@@ -425,5 +691,111 @@ mod tests {
         assert_eq!(scaling_mode_from_value(0.3), ScalingMode::Fit);
         assert_eq!(scaling_mode_from_value(0.6), ScalingMode::Stretch);
         assert_eq!(scaling_mode_from_value(1.0), ScalingMode::Center);
+    }
+
+    // ── apply_mod_param: structured-result behavior (no GPU) ──────────
+
+    #[test]
+    fn mod_param_known_returns_ok_and_sets_value() {
+        let mut src = ModulationSource::sine_lfo(1.0);
+        assert!(apply_mod_param(&mut src, "frequency", 0.5).is_ok());
+        if let ModulationSource::LFO { frequency, .. } = src {
+            // 0.01 + 0.5 * 9.99 = 5.005
+            assert!((frequency - 5.005).abs() < 1e-4, "frequency = {frequency}");
+        } else {
+            panic!("expected LFO");
+        }
+    }
+
+    #[test]
+    fn mod_param_unknown_returns_unknown_param() {
+        let mut src = ModulationSource::sine_lfo(1.0);
+        let err = apply_mod_param(&mut src, "bogus", 0.5).unwrap_err();
+        assert_eq!(
+            err,
+            ParamRouteError::UnknownParam {
+                scope: "LFO",
+                name: "bogus".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn mod_param_audio_band_params_are_routable() {
+        // Regression: freq_low/freq_high/gain/noise_gate were previously silent
+        // no-ops (only `smoothing` was handled).
+        let mut src = ModulationSource::audio_from_preset(crate::modulation::AudioBandPreset::Low);
+        assert!(apply_mod_param(&mut src, "freq_low", 0.0).is_ok());
+        assert!(apply_mod_param(&mut src, "gain", 1.0).is_ok());
+        assert!(apply_mod_param(&mut src, "noise_gate", 1.0).is_ok());
+        if let ModulationSource::AudioBand {
+            freq_low,
+            gain,
+            noise_gate,
+            ..
+        } = src
+        {
+            assert!((freq_low - 20.0).abs() < 1e-3, "freq_low = {freq_low}");
+            assert!((gain - 4.0).abs() < 1e-4, "gain = {gain}");
+            assert!((noise_gate - 0.5).abs() < 1e-4, "noise_gate = {noise_gate}");
+        } else {
+            panic!("expected AudioBand");
+        }
+    }
+
+    // ── WS3(a): typed value path preserves non-scalar params ──────────
+
+    fn color_params() -> crate::ShaderParams {
+        let input: crate::isf::ISFInput = serde_json::from_value(serde_json::json!({
+            "NAME": "tint",
+            "TYPE": "color",
+            "DEFAULT": [0.0, 0.0, 0.0, 1.0],
+        }))
+        .unwrap();
+        crate::ShaderParams::from_inputs(&[input])
+    }
+
+    #[test]
+    fn typed_param_preserves_color_channels() {
+        let mut params = color_params();
+        apply_typed_param(&mut params, "tint", ParamValue::Color([0.1, 0.2, 0.3, 0.4]));
+        match params.values.get("tint") {
+            Some(ParamValue::Color(c)) => {
+                assert_eq!(*c, [0.1, 0.2, 0.3, 0.4], "all channels must survive");
+            }
+            other => panic!("expected Color, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn param_value_to_norm_f32_flattens_all_variants() {
+        assert_eq!(param_value_to_norm_f32(&ParamValue::Float(0.7)), 0.7);
+        assert_eq!(param_value_to_norm_f32(&ParamValue::Bool(true)), 1.0);
+        assert_eq!(param_value_to_norm_f32(&ParamValue::Bool(false)), 0.0);
+        assert_eq!(param_value_to_norm_f32(&ParamValue::Long(3)), 3.0);
+        assert_eq!(
+            param_value_to_norm_f32(&ParamValue::Color([0.9, 0.1, 0.2, 1.0])),
+            0.9
+        );
+        assert_eq!(
+            param_value_to_norm_f32(&ParamValue::Point2D([0.25, 0.75])),
+            0.25
+        );
+    }
+
+    #[test]
+    fn error_display_is_human_readable() {
+        let e = ParamRouteError::unknown_entity(EntityKind::Deck, "abc123");
+        assert_eq!(e.to_string(), "unknown deck: abc123");
+        let e = ParamRouteError::IndexOutOfRange {
+            kind: EntityKind::Step,
+            index: 9,
+            len: 8,
+        };
+        assert_eq!(e.to_string(), "step index 9 out of range (len 8)");
+        let e = ParamRouteError::UnknownPath {
+            path: "foo/bar".to_string(),
+        };
+        assert_eq!(e.to_string(), "unknown parameter path: foo/bar");
     }
 }

--- a/src/usecases/ui/panels/deck_detail.rs
+++ b/src/usecases/ui/panels/deck_detail.rs
@@ -1367,7 +1367,7 @@ pub(super) fn render_selected_deck_detail(
                                     let deck_uuid_eff = deck.uuid.clone();
                                     let eff_uuid_assign = eff_uuid.clone();
                                     let eff_uuid_remove = eff_uuid.clone();
-                                    let eff_midi_prefix = format!("deck/{}/effect/{}", deck_uuid_eff, eff_idx_copy);
+                                    let eff_midi_prefix = format!("deck/{}/effect/{}", deck_uuid_eff, eff_uuid);
                                     widgets::render_effect_params(
                                         ui,
                                         &eff_params.params,

--- a/src/usecases/ui/panels/effects.rs
+++ b/src/usecases/ui/panels/effects.rs
@@ -61,7 +61,7 @@ pub(super) fn render_master_effect_detail(
                                             if !eff_params.params.is_empty() {
                                                 let eff_idx_copy = eff_idx;
                                                 let midi_prefix =
-                                                    format!("master/effect/{}", eff_idx_copy);
+                                                    format!("master/effect/{}", eff_uuid);
                                                 widgets::render_effect_params(
                                                     ui,
                                                     &eff_params.params,
@@ -329,10 +329,8 @@ pub(super) fn render_channel_effect_detail(
                                                 let eff_idx_copy = eff_idx;
                                                 let ch_uuid = ch.uuid.clone();
                                                 let _ch_uuid = ch_uuid.clone();
-                                                let midi_prefix = format!(
-                                                    "ch/{}/effect/{}",
-                                                    ch_uuid, eff_idx_copy
-                                                );
+                                                let midi_prefix =
+                                                    format!("ch/{}/effect/{}", ch_uuid, eff_uuid);
                                                 widgets::render_effect_params(
                                                     ui,
                                                     &eff_params.params,

--- a/src/usecases/ui/panels/modulation.rs
+++ b/src/usecases/ui/panels/modulation.rs
@@ -119,7 +119,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut freq = *frequency;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("Freq:").small());
-                                    let path = format!("mod/{}/frequency", idx);
+                                    let path = format!("mod/{}/frequency", sid);
                                     if render_mod_learn_slider(ui, &mut freq, 0.01..=10.0, |s| s.logarithmic(true).show_value(true).suffix("Hz"), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateLFOFrequency { source_id: sid.clone(), frequency: freq });
                                     }
@@ -128,7 +128,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut amp = *amplitude;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("Amp:").small());
-                                    let path = format!("mod/{}/amplitude", idx);
+                                    let path = format!("mod/{}/amplitude", sid);
                                     if render_mod_learn_slider(ui, &mut amp, 0.0..=1.0, |s| s.show_value(true), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateLFOAmplitude { source_id: sid.clone(), amplitude: amp });
                                     }
@@ -137,7 +137,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut ph = *phase;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("Phase:").small());
-                                    let path = format!("mod/{}/phase", idx);
+                                    let path = format!("mod/{}/phase", sid);
                                     if render_mod_learn_slider(ui, &mut ph, 0.0..=1.0, |s| s.show_value(false), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateLFOPhase { source_id: sid.clone(), phase: ph });
                                     }
@@ -227,7 +227,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut fl = *freq_low;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("Lo:").small());
-                                    let path = format!("mod/{}/freq_low", idx);
+                                    let path = format!("mod/{}/freq_low", sid);
                                     if render_mod_learn_slider(ui, &mut fl, 20.0..=20000.0, |s| s.logarithmic(true).suffix("Hz"), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateAudioFreqLow { source_id: sid.clone(), freq_low: fl });
                                     }
@@ -235,7 +235,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut fh = *freq_high;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("Hi:").small());
-                                    let path = format!("mod/{}/freq_high", idx);
+                                    let path = format!("mod/{}/freq_high", sid);
                                     if render_mod_learn_slider(ui, &mut fh, 20.0..=20000.0, |s| s.logarithmic(true).suffix("Hz"), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateAudioFreqHigh { source_id: sid.clone(), freq_high: fh });
                                     }
@@ -244,7 +244,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut g = *gain;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("Gain:").small());
-                                    let path = format!("mod/{}/gain", idx);
+                                    let path = format!("mod/{}/gain", sid);
                                     if render_mod_learn_slider(ui, &mut g, 0.0..=4.0, |s| s.show_value(true), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateAudioGain { source_id: sid.clone(), gain: g });
                                     }
@@ -254,7 +254,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut sm = *smoothing;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("Smooth:").small());
-                                    let path = format!("mod/{}/smoothing", idx);
+                                    let path = format!("mod/{}/smoothing", sid);
                                     if render_mod_learn_slider(ui, &mut sm, 0.0..=0.99, |s| s.show_value(false), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateAudioSmoothing { source_id: sid.clone(), smoothing: sm });
                                     }
@@ -298,7 +298,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                             }
                             ModSourceUI::ADSR { attack, decay, sustain, release, stage: _ } => {
                                 // Combined gate button: press → trigger, release → gate off
-                                let gate_path = format!("mod/{}/gate", idx);
+                                let gate_path = format!("mod/{}/gate", sid);
                                 let any_learn = data.midi_learn_active || data.keyboard_learn_active;
                                 let gate_id = ui.id().with(("adsr_gate", idx));
                                 let was_held = ui.memory(|m| m.data.get_temp::<bool>(gate_id).unwrap_or(false));
@@ -364,7 +364,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut a = *attack;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("A:").small());
-                                    let path = format!("mod/{}/attack", idx);
+                                    let path = format!("mod/{}/attack", sid);
                                     if render_mod_learn_slider(ui, &mut a, 0.001..=5.0, |s| s.logarithmic(true).suffix("s").show_value(true), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateADSRAttack { source_id: sid.clone(), attack: a });
                                     }
@@ -373,7 +373,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut d = *decay;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("D:").small());
-                                    let path = format!("mod/{}/decay", idx);
+                                    let path = format!("mod/{}/decay", sid);
                                     if render_mod_learn_slider(ui, &mut d, 0.001..=5.0, |s| s.logarithmic(true).suffix("s").show_value(true), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateADSRDecay { source_id: sid.clone(), decay: d });
                                     }
@@ -382,7 +382,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut s = *sustain;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("S:").small());
-                                    let path = format!("mod/{}/sustain", idx);
+                                    let path = format!("mod/{}/sustain", sid);
                                     if render_mod_learn_slider(ui, &mut s, 0.0..=1.0, |s| s.show_value(true), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateADSRSustain { source_id: sid.clone(), sustain: s });
                                     }
@@ -391,7 +391,7 @@ pub(super) fn render_modulation_section(ui: &mut egui::Ui, data: &UIData, action
                                 let mut r = *release;
                                 ui.horizontal(|ui| {
                                     ui.label(egui::RichText::new("R:").small());
-                                    let path = format!("mod/{}/release", idx);
+                                    let path = format!("mod/{}/release", sid);
                                     if render_mod_learn_slider(ui, &mut r, 0.001..=5.0, |s| s.logarithmic(true).suffix("s").show_value(true), &path, data, actions) {
                                         actions.modulation_actions.push(ModulationAction::UpdateADSRRelease { source_id: sid.clone(), release: r });
                                     }
@@ -459,7 +459,7 @@ fn render_step_sequencer_controls(
     let mut r = rate;
     ui.horizontal(|ui| {
         ui.label(egui::RichText::new("Rate:").small());
-        let path = format!("mod/{}/rate", idx);
+        let path = format!("mod/{}/rate", sid);
         if render_mod_learn_slider(
             ui,
             &mut r,
@@ -687,7 +687,7 @@ fn render_step_sequencer_controls(
                 egui::pos2(x0, rect.top()),
                 egui::vec2(step_w, rect.height()),
             );
-            let step_path = format!("mod/{}/step/{}", idx, step_idx);
+            let step_path = format!("mod/{}/step/{}", sid, step_idx);
             if data.midi_learn_active {
                 let is_target = data.midi_learn_target.as_deref() == Some(step_path.as_str());
                 if is_target {


### PR DESCRIPTION
warning: this will change how some params are addressed to use uuid over idx. uuid is more stable compared to positional idx that could change. most of the rest of varda's entity addresses use uuid already, so this fix brings the stragglers in line with the pattern. users will have to remap their midi surfaces. small enough user count that this shouldnt hurt that much. hope these arent famous last words. 